### PR TITLE
Implement intial input operations to create a list of filings

### DIFF
--- a/src/idi_corporate_structure/processor/extractor.py
+++ b/src/idi_corporate_structure/processor/extractor.py
@@ -1,0 +1,23 @@
+
+# Standard imports
+from abc import ABC, abstractmethod
+
+# Application imports
+from idi_corporate_structure.processor.types import Filing, Subsidiary
+
+
+class Extractor(ABC):
+    """Interface for extracing subsidiaries from documents."""
+
+    @abstractmethod
+    def extract(self, documents: list, filing: Filing) -> list[Subsidiary]:
+        """Extact subsidiaries from documents."""
+        ...
+
+
+class GptExtractor(Extractor):
+    """Extracts subsidiaries using GPT."""
+
+    def extract(self, documents: list, filing: Filing) -> list[Subsidiary]:
+        """Use GPT to extract structured subsidiary data."""
+        pass

--- a/src/idi_corporate_structure/processor/failures.py
+++ b/src/idi_corporate_structure/processor/failures.py
@@ -1,0 +1,64 @@
+"""Corporate structure failure classification."""
+
+# Standard library imports
+from enum import StrEnum
+
+# Application imports
+from idi_corporate_structure.common.failures import FailureClassifier
+
+_HTTP_RATE_LIMIT = 429
+_HTTP_OK = 200
+_HTTP_CLIENT_ERROR_MIN = 400
+_HTTP_SERVER_ERROR_MIN = 500
+
+
+class FailureType(StrEnum):
+    """Failure type for the corporate structure pipeline."""
+
+    MISMATCHED_LENGTHS = "mismatched_lengths"    # Parallel filing arrays have unequal lengths
+    NO_FORM_DATA = "no_form_data"                # Filing arrays have no data
+    NO_10K_FILINGS = "no_10k_filings"            # CIK exists but has no 10-K forms
+    NO_FILING_DIRECTORY = "no_filing_directory"  # SEC queried filing but no directory listing was found
+    NO_EXHIBIT_21 = "no_exhibit_21"              # 10-K has no Exhibit 21 subsidiary list
+    EXTRACTION_FAILED = "extraction_failed"      # GPT returned no structured data
+    API_ERROR = "api_error"                      # HTTP failure fetching filing document
+    RATE_LIMIT = "rate_limit"                    # SEC rate limit (429)
+
+
+class CorporateStructureFailureClassifier(FailureClassifier):
+    """Classifies failures for the corporate structure pipeline."""
+
+    _DO_NOT_RETRY = frozenset({
+        FailureType.MISMATCHED_LENGTHS,
+        FailureType.NO_FORM_DATA,
+        FailureType.NO_10K_FILINGS,
+        FailureType.NO_EXHIBIT_21,
+    })
+
+    @property
+    def do_not_retry(self) -> frozenset:
+        """Return the set of failure types that should not be retried."""
+        return self._DO_NOT_RETRY
+
+    def classify_from_response(self, response: dict, **kwargs) -> FailureType:
+        """Classify failure from an HTTP response fetching a filing document.
+
+        Args:
+            response: Response dict with status_code and optional error.
+
+        Returns:
+            The classified FailureType.
+        """
+        status_code = response.get("status_code")
+        has_error = "error" in response
+
+        if has_error or status_code is None:
+            return FailureType.API_ERROR
+
+        if status_code == _HTTP_RATE_LIMIT:
+            return FailureType.RATE_LIMIT
+
+        if _HTTP_CLIENT_ERROR_MIN <= status_code < _HTTP_SERVER_ERROR_MIN:
+            return FailureType.API_ERROR
+
+        return FailureType.API_ERROR

--- a/src/idi_corporate_structure/processor/pipeline.py
+++ b/src/idi_corporate_structure/processor/pipeline.py
@@ -1,0 +1,239 @@
+# Standard application imports
+import json
+import os
+import re
+import zipfile
+from abc import ABC, abstractmethod
+
+# Third party imports
+from tqdm import tqdm
+
+# Application imports
+from idi_corporate_structure.common.api import SecClient
+from idi_corporate_structure.common.failures import FailureRegistry
+from idi_corporate_structure.common.logs import get_logger
+from idi_corporate_structure.common.storage import open_zip
+from idi_corporate_structure.processor.extractor import GptExtractor
+from idi_corporate_structure.processor.failures import CorporateStructureFailureClassifier, FailureType
+from idi_corporate_structure.processor.types import Filing, PipelineConfig, PipelineStats, Subsidiary
+
+
+class Pipeline(ABC):
+    """Baseline class for processing piplines."""
+
+    def __init__(self, config: PipelineConfig, sec_client: SecClient, extractor: GptExtractor) -> None:
+        self.config = config
+        self.extractor = extractor
+        self.logger = get_logger("Pipeline")
+        self.sec_client = sec_client
+        self.stats = PipelineStats()
+
+    @abstractmethod
+    def load_input(self) -> list:
+        """Load input data and return a list of items to process."""
+        ...
+
+    @abstractmethod
+    def process(self, input_list: list) -> list:
+        """Process each item in the input list and return a list of results."""
+        ...
+
+    @abstractmethod
+    def save_output(self, processed_list: list) -> None:
+        """Saves processed items list."""
+        ...
+
+    def display_stats(self) -> None:
+        """Display processing stats."""
+        pass
+
+    def run(self) -> None:
+        """Run the pipeline."""
+        input_data = self.load_input()
+        self.logger.info("Located %d input data items.", len(input_data))
+        results = self.process(input_data)
+        self.logger.info("Located %d result data items.", len(results))
+        self.save_output(results)
+        self.display_stats()
+
+
+class SubsidiaryPipeline(Pipeline):
+
+    EX = re.compile(r"\BEX")
+    IS_10K = re.compile("10-?K")
+    IS_DATE = re.compile("[0-9]{4}-[0-9]{2}-[0-9]{2}")
+    TWENTYONE = re.compile("[^0-9]21")
+
+    SEC_HEADERS = { "User-Agent": "Nicole Tebaldi ntebaldi@uchicago.edu" }
+    SEC_URL = "https://www.sec.gov/Archives/edgar/data"
+
+    def __init__(self, config: PipelineConfig, sec_client: SecClient, extractor: GptExtractor):
+        super().__init__(config, sec_client, extractor)
+        self.failure_registry = FailureRegistry(
+            config.failure_file,
+            classifier=CorporateStructureFailureClassifier(),
+            flush_every=config.failure_flush_every
+        )
+        self.rows = []
+
+    def _zip_file_data(self, data: dict, filename: str, cik: str) -> zip | None:
+        """Locate and returned zipped file data.
+
+        Args:
+            data: Data to retrieve specific file data from
+            filename: Name of file data was retrieved from
+            cik: Identifier of file data was retrieved from
+        """
+
+        forms = data.get("filings", {}).get("recent", {}).get("form", [])
+        accession_numbers = data.get("filings", {}).get("recent", {}).get("accessionNumber", [])
+        primary_documents = data.get("filings", {}).get("recent", {}).get("primaryDocument", [])
+        filing_dates = data.get("filings", {}).get("recent", {}).get("filingDate", [])
+
+        if len({len(forms), len(accession_numbers), len(primary_documents), len(filing_dates)}) != 1:
+            self.logger.error("Filename: %s has forms with mismatched data lengths.", filename)
+            self.stats.failed_filings += 1
+            self.failure_registry.add(cik, filename, failure_type=FailureType.MISMATCHED_LENGTHS)
+            return None
+
+        if not any([forms, accession_numbers, primary_documents, filing_dates]):
+            self.logger.debug("Filename: %s has forms without data.", filename)
+            self.stats.failed_filings += 1
+            self.failure_registry.add(cik, filename, failure_type=FailureType.NO_FORM_DATA)
+            return None
+
+        return zip(forms, accession_numbers, primary_documents, filing_dates)
+
+    def _create_filing(self, accession_number: str, primary_document: str, cik: str, filing_date: str, form: str) -> Filing:
+        """Create Filing object with form data.
+
+        Args:
+            accession_number: String taken from form data
+            primary_document: String document URL from form data
+            cik: String CIK identifier
+            filing_date: String date of filing
+            form: String name of form
+        """
+        accession = accession_number.replace("-", "")
+        directory = f"{self.SEC_URL}/{cik}/{accession}/index.json"
+
+        if primary_document != "" and primary_document.split(".")[-1].upper() in ("HTM", "HTML"):
+            primary = f"{self.SEC_URL}/{cik}/{accession}/{primary_document}"
+        else:
+            primary = ""
+
+        filing = Filing(
+            cik=cik,
+            filing_date=filing_date,
+            form_type=form,
+            accession_number=accession_number,
+            directory=directory,
+            primary_document=primary
+        )
+        return filing
+
+    def _parse_file(self, zf: zipfile.ZipFile, filename: str) -> list[Filing]:
+        """Parse file contents and save as a row in the rows list.
+
+        Parses: cik, date, form, accession number, directory, and primary document
+
+        Args:
+            filename: The filename to parse data from
+
+        Returns:
+            List of Filing objects with form data
+        """
+        filings = []
+        if filename.startswith("CIK") and filename.endswith(".json"):
+
+            with zf.open(filename) as file:
+                data = json.load(file)
+
+            cik = filename[3:-5]
+            data_zip = self._zip_file_data(data, filename, cik)
+
+            if data_zip:
+                for form, accession_number, primary_document, filing_date in data_zip:
+                    if self.IS_10K.match(form):
+                        filings.append(self._create_filing(
+                            accession_number=accession_number,
+                            primary_document=primary_document,
+                            cik=cik,
+                            filing_date=filing_date,
+                            form=form
+                        ))
+                        self.stats.total_filing += 1
+
+                    else:
+                        self.logger.debug("Filename: %s does not have a 10K form.", filename)
+                        self.stats.failed_filings += 1
+                        self.failure_registry.add(cik, filename, failure_type=FailureType.NO_10K_FILINGS)
+
+        return filings
+
+    def load_input(self) -> list[Filing]:
+        """Load input data from the SEC and return a list of filings.
+
+        Returns:
+            A list of Filing objects
+        """
+        filings = []
+        with open_zip(self.config.input_file, headers=self.SEC_HEADERS) as zf:
+            namelist = zf.namelist()
+            self.logger.info("Total # of files to process: %d", len(namelist))
+
+            count = 0
+            for filename in tqdm(namelist):
+                filings.extend(self._parse_file(zf, filename))
+                count += 1
+                if count == 500:
+                    # from dataclasses import asdict
+                    # print(json.dumps([asdict(f) for f in filings], indent=2))
+                    # print(len(filings))
+                    break
+
+        return filings
+
+    def process(self, input_list: list[Filing]) -> list[Subsidiary]:
+        """Process input filing list to retrieve subsidiary data."""
+        return []
+
+    def save_output(self, processed_list: list[Subsidiary]) -> None:
+        """Save subsidiary list output."""
+        pass
+
+    def run(self) -> None:
+        """Run the pipeline, flushing any buffered failures on completion."""
+
+        try:
+            super().run()
+        finally:
+            self.failure_registry.flush()
+
+
+if __name__ == "__main__":
+    # uv run python3 -m src.idi_corporate_structure.processor.pipeline
+    import datetime
+
+    start = datetime.datetime.now()
+
+    config = PipelineConfig(
+        # input_file="https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip",
+        input_file = "/Users/ntebaldi/Documents/workspace/11hour/ftm2j/data/corporate-struct/input/submissions.zip",
+        failure_file= "/Users/ntebaldi/Documents/workspace/11hour/ftm2j/data/corporate-struct/failures/failures.json"
+    )
+
+    sec_client = SecClient()
+
+    extractor = GptExtractor()
+
+    sub_pipeline = SubsidiaryPipeline(
+        config=config,
+        sec_client=sec_client,
+        extractor=extractor
+    )
+
+    sub_pipeline.run()
+
+    end = datetime.datetime.now()
+    print(f"Elasped time: {end - start}")

--- a/src/idi_corporate_structure/processor/types.py
+++ b/src/idi_corporate_structure/processor/types.py
@@ -1,0 +1,53 @@
+# Standard application imports
+import pathlib
+from dataclasses import dataclass
+
+
+_REMOTE_SCHEMES = ("s3://", "https://", "http://", "gs://")
+
+
+def _is_local(path: str) -> bool:
+    return not path.startswith(_REMOTE_SCHEMES)
+
+
+@dataclass
+class Filing:
+    cik: str
+    filing_date: str
+    form_type: str
+    accession_number: str
+    directory: str
+    primary_document: str
+
+
+@dataclass
+class PipelineConfig:
+    input_file: str
+    failure_file: str
+    failure_flush_every: int = 50
+
+    def __post_init__(self) -> None:
+        "Validate existence of local files."
+        if _is_local(self.input_file) and not pathlib.Path(self.input_file).exists():
+            raise FileNotFoundError(f"Input file not found: {self.input_file}")
+        if _is_local(self.failure_file) and not pathlib.Path(self.failure_file).parent.exists():
+            raise FileNotFoundError(
+                f"Failure file directory does not exist: {pathlib.Path(self.failure_file).parent}"
+            )
+
+
+@dataclass
+class PipelineStats:
+    total_filing: int = 0
+    failed_filings: int = 0
+    skipped_filings: int = 0
+    total_subsidiaries: int = 0
+    failed_subsidiaries: int = 0
+
+
+@dataclass
+class Subsidiary:
+    parent_cik: str
+    name: str
+    location: str
+    filing_date: str


### PR DESCRIPTION
# summary

- Adds processor/types.py: core dataclasses — Filing, Subsidiary, PipelineConfig (with local path validation), and PipelineStats
- Adds processor/failures.py: FailureType enum covering 8 pipeline-specific failure categories and CorporateStructureFailureClassifier wiring permanent failures (mismatched lengths, no form data, no 10-K, no Exhibit 21) to the common FailureClassifier interface
- Adds processor/extractor.py: Extractor abstract base class and a stub GptExtractor for extracting Subsidiary records from SEC documents
- Adds processor/pipeline.py: Pipeline ABC (load_input → process → save_output) and SubsidiaryPipeline implementing load_input — reads SEC bulk submissions ZIP (local or HTTPS), parses CIK*.json files, filters to 10-K filings, and emits a list of Filing objects; process and save_output are stubbed for subsequent PRs

Issue: #2 