### PR TITLE
Refine failure handling in the corporate structure processing

### DIFF
--- a/src/idi_corporate_structure/common/failures.py
+++ b/src/idi_corporate_structure/common/failures.py
@@ -96,7 +96,7 @@ class FailureRegistry:
         self._entries = {tuple(e) for e in entries_data if len(e) >= _MIN_ENTRY_LEN}
         self._reasons = {}
         for entry in self._entries:
-            key = f"{entry[0]} {entry[1]}"
+            key = " ".join(entry)
             if key in reasons_data:
                 self._reasons[entry] = reasons_data[key]
 
@@ -106,22 +106,20 @@ class FailureRegistry:
             return
 
         entries_list = [list(e) for e in self._entries]
-        reasons_dict = {f"{e[0]} {e[1]}": self._reasons.get(e, "") for e in self._entries}
+        reasons_dict = {" ".join(e): self._reasons.get(e, "") for e in self._entries}
         save_json(self.file_path, {"entries": entries_list, "reasons": reasons_dict})
 
-    def add(self, cik: str, accession_number: str, failure_type: StrEnum) -> None:
+    def add(self, key: tuple[str, str], failure_type: StrEnum) -> None:
         """Add a permanent failure entry.
 
         Args:
-            cik: The CIK of the filing entity.
-            accession_number: The accession number of the filing.
+            key: Tuple of identifier and associated file or relevant metadata.
             failure_type: The classified failure type.
         """
         if self._classifier.is_retryable(failure_type):
             return
 
         with self._lock:
-            key = (cik, accession_number)
             if key in self._entries:
                 return
 
@@ -141,7 +139,7 @@ class FailureRegistry:
         """Set-like membership check.
 
         Args:
-            key: Tuple of (cik, accession_number).
+            key: Tuple of identifier and associated file or relevant metadata.
 
         Returns:
             True if the filing should not be retried.

--- a/src/idi_corporate_structure/processor/failures.py
+++ b/src/idi_corporate_structure/processor/failures.py
@@ -18,6 +18,7 @@ class FailureType(StrEnum):
     MISMATCHED_LENGTHS = "mismatched_lengths"  # Parallel filing arrays have unequal lengths
     NO_FORM_DATA = "no_form_data"  # Filing arrays have no data
     NO_10K_FILINGS = "no_10k_filings"  # CIK exists but has no 10-K forms
+    NO_OVERFLOW_FILINGS = "no_overflow_filings"  # CIK exists but has no overflow filings
     NO_FILING_DIRECTORY = (
         "no_filing_directory"  # SEC queried filing but no directory listing was found
     )
@@ -39,6 +40,7 @@ class CorporateStructureFailureClassifier(FailureClassifier):
             FailureType.NO_EXHIBIT_CONTENT,
             FailureType.NO_FILING_DIRECTORY,
             FailureType.DOCUMENT_ERROR,
+            FailureType.NO_OVERFLOW_FILINGS,
         }
     )
 

--- a/src/idi_corporate_structure/processor/pipeline.py
+++ b/src/idi_corporate_structure/processor/pipeline.py
@@ -223,11 +223,11 @@ class SubsidiaryPipeline(Pipeline):
                         self.stats.increment("total_filing")
 
                     else:
-                        self.logger.debug("Filename: %s does not have a 10K form.", filename)
-                        self.stats.increment("failed_filings")
-                        self.failure_registry.add(
-                            company_data["cik"], filename, failure_type=FailureType.NO_10K_FILINGS
-                        )
+                        self.logger.debug("Filename: %s skipping non-10K form: %s.", filename, form)
+
+                if not filings:
+                    self.stats.increment("failed_filings")
+                    self.failure_registry.add(company_data["cik"], filename, failure_type=FailureType.NO_10K_FILINGS)
 
         return filings
 

--- a/src/idi_corporate_structure/processor/pipeline.py
+++ b/src/idi_corporate_structure/processor/pipeline.py
@@ -87,7 +87,7 @@ class SubsidiaryPipeline(Pipeline):
     TWENTYONE = re.compile("[^0-9]21")
     IS_OVERFLOW = re.compile(r"-submissions-\d+\.json$")
 
-    _INPUT_SAMPLE_SIZE = 10  # TODO: Remove after done testing
+    _INPUT_SAMPLE_SIZE = 100  # TODO: Remove after done testing
     _SUPPORTED_EXHIBIT_EXTENSIONS = frozenset({"HTM", "HTML", "TXT", "PDF"})
 
     def __init__(
@@ -103,7 +103,9 @@ class SubsidiaryPipeline(Pipeline):
         )
         self.rows = []
 
-    def _retrieve_overflow_filings(self, data: dict, cik: str, zf: zipfile.ZipFile) -> tuple[list, list, list, list]:
+    def _retrieve_overflow_filings(
+        self, data: dict, cik: str, zf: zipfile.ZipFile
+    ) -> tuple[list, list, list, list]:
         """Retrieve overflow filings from the SEC submissions JSON.
 
         Args:
@@ -119,13 +121,14 @@ class SubsidiaryPipeline(Pipeline):
         primary_documents = []
         filing_dates = []
         for entry in data.get("filings", {}).get("files", []):
-
             overflow_filename = entry.get("name", "")
             if not overflow_filename:
                 continue
 
             if (cik, overflow_filename) in self.failure_registry:
-                self.logger.debug("Skipping overflow file — permanent failure recorded: %s", overflow_filename)
+                self.logger.debug(
+                    "Skipping overflow file — permanent failure recorded: %s", overflow_filename
+                )
                 self.stats.increment("skipped_filings")
                 continue
 
@@ -141,11 +144,15 @@ class SubsidiaryPipeline(Pipeline):
             except KeyError:
                 self.logger.error("Overflow file not found: %s", overflow_filename)
                 self.stats.increment("failed_filings")
-                self.failure_registry.add(cik, overflow_filename, failure_type=FailureType.NO_OVERFLOW_FILINGS)
+                self.failure_registry.add(
+                    (cik, overflow_filename), failure_type=FailureType.NO_OVERFLOW_FILINGS
+                )
 
         return forms, accession_numbers, primary_documents, filing_dates
 
-    def _zip_file_data(self, data: dict, filename: str, cik: str, zf: zipfile.ZipFile) -> zip | None:
+    def _zip_file_data(
+        self, data: dict, filename: str, cik: str, zf: zipfile.ZipFile
+    ) -> zip | None:
         """Locate and returned zipped file data.
 
         Args:
@@ -161,7 +168,9 @@ class SubsidiaryPipeline(Pipeline):
         filing_dates = data.get("filings", {}).get("recent", {}).get("filingDate", [])
 
         # Retrieve overflow filings
-        o_forms, o_accession_numbers, o_primary_documents, o_filing_dates = self._retrieve_overflow_filings(data, cik, zf)
+        o_forms, o_accession_numbers, o_primary_documents, o_filing_dates = (
+            self._retrieve_overflow_filings(data, cik, zf)
+        )
         forms.extend(o_forms)
         accession_numbers.extend(o_accession_numbers)
         primary_documents.extend(o_primary_documents)
@@ -173,13 +182,13 @@ class SubsidiaryPipeline(Pipeline):
         ):
             self.logger.error("Filename: %s has forms with mismatched data lengths.", filename)
             self.stats.increment("failed_filings")
-            self.failure_registry.add(cik, filename, failure_type=FailureType.MISMATCHED_LENGTHS)
+            self.failure_registry.add((cik, filename), failure_type=FailureType.MISMATCHED_LENGTHS)
             return None
 
         if not any([forms, accession_numbers, primary_documents, filing_dates]):
             self.logger.debug("Filename: %s has forms without data.", filename)
             self.stats.increment("failed_filings")
-            self.failure_registry.add(cik, filename, failure_type=FailureType.NO_FORM_DATA)
+            self.failure_registry.add((cik, filename), failure_type=FailureType.NO_FORM_DATA)
             return None
 
         return zip(forms, accession_numbers, primary_documents, filing_dates)
@@ -219,7 +228,9 @@ class SubsidiaryPipeline(Pipeline):
 
         if not filings:
             self.stats.increment("failed_filings")
-            self.failure_registry.add(company_data["cik"], source_filename, failure_type=FailureType.NO_10K_FILINGS)
+            self.failure_registry.add(
+                (company_data["cik"], source_filename), failure_type=FailureType.NO_10K_FILINGS
+            )
 
         return filings
 
@@ -298,7 +309,9 @@ class SubsidiaryPipeline(Pipeline):
 
         # Skip files that had a permanent failure on a previous run
         if (company_data["cik"], filename) in self.failure_registry:
-            self.logger.debug("Skipping permanent failure for filing: %s - %s", company_data["cik"], filename)
+            self.logger.debug(
+                "Skipping permanent failure for filing: %s - %s", company_data["cik"], filename
+            )
             self.stats.increment("skipped_filings")
             return filings
 
@@ -319,7 +332,6 @@ class SubsidiaryPipeline(Pipeline):
         with open_zip(self.config.input_file, headers=self.sec_client.SEC_HEADERS) as zf:
             namelist = zf.namelist()
             namelist = namelist[: self._INPUT_SAMPLE_SIZE]  # TODO: Remove after done testing
-            namelist = ["CIK0000001750.json"]  # TODO: Remove after done testing
             self.logger.info("Total # of files to process: %d", len(namelist))
 
             for filename in tqdm(namelist):
@@ -327,7 +339,11 @@ class SubsidiaryPipeline(Pipeline):
                 if filings_for_file:
                     filings.extend(filings_for_file)
 
-        self.logger.info("Located %d filings for %d files", len(filings), len(namelist) - self.stats.skipped_filings)
+        self.logger.info(
+            "Located %d filings for %d files",
+            len(filings),
+            len(namelist) - self.stats.skipped_filings,
+        )
         self.logger.info("Skipped %d files", self.stats.skipped_filings)
 
         return filings
@@ -354,9 +370,7 @@ class SubsidiaryPipeline(Pipeline):
                     e,
                 )
                 self.stats.increment("failed_subsidiaries")
-                self.failure_registry.add(
-                    filing.cik, filing.filename, FailureType.DOCUMENT_ERROR
-                )
+                self.failure_registry.add((filing.cik, filing.filename), FailureType.DOCUMENT_ERROR)
 
             except Exception as _:
                 self.logger.error(
@@ -367,7 +381,7 @@ class SubsidiaryPipeline(Pipeline):
                 )
                 self.stats.increment("failed_subsidiaries")
                 self.failure_registry.add(
-                    filing.cik, filing.filename, FailureType.EXTRACTION_FAILED
+                    (filing.cik, filing.filename), FailureType.EXTRACTION_FAILED
                 )
 
             finally:
@@ -405,7 +419,7 @@ class SubsidiaryPipeline(Pipeline):
             )
             self.stats.increment("failed_subsidiaries")
             self.failure_registry.add(
-                filing.cik, filing.filename, FailureType.NO_FILING_DIRECTORY
+                (filing.cik, filing.filename), FailureType.NO_FILING_DIRECTORY
             )
             return []
         self.sec_client.rate_limit()
@@ -434,7 +448,7 @@ class SubsidiaryPipeline(Pipeline):
                 self.logger.error("Failed to extract PDF content: %s", sec_url)
                 self.stats.increment("failed_subsidiaries")
                 self.failure_registry.add(
-                    filing.cik, filing.filename, FailureType.NO_EXHIBIT_CONTENT
+                    (filing.cik, filing.filename), FailureType.NO_EXHIBIT_CONTENT
                 )
         return exhibit_content
 
@@ -461,9 +475,7 @@ class SubsidiaryPipeline(Pipeline):
                 filing.accession_number,
             )
             self.stats.increment("failed_subsidiaries")
-            self.failure_registry.add(
-                filing.cik, filing.filename, FailureType.NO_EXHIBIT_CONTENT
-            )
+            self.failure_registry.add((filing.cik, filing.filename), FailureType.NO_EXHIBIT_CONTENT)
         return exhibit_content
 
     def _fetch_exhibit_content(self, filing: Filing, item: dict) -> dict:

--- a/src/idi_corporate_structure/processor/pipeline.py
+++ b/src/idi_corporate_structure/processor/pipeline.py
@@ -334,7 +334,7 @@ class SubsidiaryPipeline(Pipeline):
             namelist = namelist[: self._INPUT_SAMPLE_SIZE]  # TODO: Remove after done testing
             self.logger.info("Total # of files to process: %d", len(namelist))
 
-            for filename in tqdm(namelist):
+            for filename in tqdm(namelist, desc="Retrieving filings"):
                 filings_for_file = self._parse_file(zf, filename)
                 if filings_for_file:
                     filings.extend(filings_for_file)
@@ -387,17 +387,27 @@ class SubsidiaryPipeline(Pipeline):
             finally:
                 work_queue.task_done()
 
-    def _results_worker(self, results_queue: queue.Queue, subsidiaries: list[Subsidiary]) -> None:
+    def _results_worker(
+        self,
+        results_queue: queue.Queue,
+        subsidiaries: list[Subsidiary],
+        extract_bar: tqdm | None = None,
+    ) -> None:
         """Results worker for the pipeline.
 
         Args:
             results_queue: Queue of results
             subsidiaries: List of subsidiaries to add to
+            extract_bar: Optional tqdm progress bar to update on each completion.
         """
         while True:
             result = results_queue.get()
             subsidiaries.extend(result)
             self.stats.increment("total_subsidiaries", len(result))
+
+            if extract_bar is not None:
+                extract_bar.update(1)
+
             results_queue.task_done()
 
     def _fetch_directory(self, filing: Filing) -> list[dict]:
@@ -542,38 +552,45 @@ class SubsidiaryPipeline(Pipeline):
         result_queue = queue.Queue()
         subsidiaries = []
 
-        # Start extract and results workers
-        extract_workers = [
-            threading.Thread(
-                target=self._extract_worker,
-                args=(work_queue, result_queue),
+        with (
+            tqdm(
+                total=len(input_list), desc="Fetching exhibits", position=0, leave=True
+            ) as fetch_bar,
+            tqdm(total=0, desc="Extracting subsidiaries", position=1, leave=True) as extract_bar,
+        ):
+            # Start extract and results workers
+            extract_workers = [
+                threading.Thread(
+                    target=self._extract_worker,
+                    args=(work_queue, result_queue),
+                    daemon=True,
+                    name=f"extract-worker-{i}",
+                )
+                for i in range(self.config.num_workers)
+            ]
+            for worker in extract_workers:
+                worker.start()
+
+            results_worker = threading.Thread(
+                target=self._results_worker,
+                args=(result_queue, subsidiaries, extract_bar),
                 daemon=True,
-                name=f"extract-worker-{i}",
+                name="results-worker",
             )
-            for i in range(self.config.num_workers)
-        ]
-        for worker in extract_workers:
-            worker.start()
+            results_worker.start()
 
-        results_worker = threading.Thread(
-            target=self._results_worker,
-            args=(result_queue, subsidiaries),
-            daemon=True,
-            name="results-worker",
-        )
-        results_worker.start()
+            # SEC operations to fetch exhibit data — one task per document
+            for filing in input_list:
+                exhibit_contents = self._fetch_exhibit(filing)
+                for exhibit_content in exhibit_contents:
+                    work_queue.put((filing, exhibit_content))
+                    extract_bar.total += 1
+                    extract_bar.refresh()
+                fetch_bar.update(1)
 
-        # SEC operations to fetch exhibit data — one task per document
-        for filing in tqdm(input_list):
-            exhibit_contents = self._fetch_exhibit(filing)
-            for exhibit_content in exhibit_contents:
-                work_queue.put((filing, exhibit_content))
-
-        # Shutdown workers as all work is done
-        self.logger.info("Waiting on extract and results workers...")
-        work_queue.join()
-        result_queue.join()
-        self.logger.info("Extract and results workers finished.")
+            # Wait for all extraction to complete
+            work_queue.join()
+            result_queue.join()
 
         return subsidiaries
 

--- a/src/idi_corporate_structure/processor/pipeline.py
+++ b/src/idi_corporate_structure/processor/pipeline.py
@@ -73,8 +73,6 @@ class Pipeline(ABC):
 
         results = self.process(input_data)
         self.logger.info("Located %d subsidiaries", len(results))
-        for r in results:
-            print(r)
 
         self.save_output(results)
         self.display_stats()
@@ -175,6 +173,7 @@ class SubsidiaryPipeline(Pipeline):
             primary_document=primary,
             company_name=company_data["name"],
             location=company_data["location"],
+            filename=company_data["filename"],
         )
 
     def _parse_file(self, zf: zipfile.ZipFile, filename: str) -> list[Filing]:
@@ -198,7 +197,15 @@ class SubsidiaryPipeline(Pipeline):
                 "cik": data.get("cik", ""),
                 "name": data.get("name", ""),
                 "location": data.get("stateOfIncorporation", ""),
+                "filename": filename,
             }
+
+            # Skip files that had a permanent failure on a previous run
+            if (company_data["cik"], filename) in self.failure_registry:
+                self.logger.debug("Skipping permanent failure for filing: %s - %s", company_data["cik"], filename)
+                self.stats.increment("skipped_filings")
+                return filings
+
             filings_zip = self._zip_file_data(data, filename, company_data["cik"])
 
             if filings_zip:
@@ -264,7 +271,7 @@ class SubsidiaryPipeline(Pipeline):
                 )
                 self.stats.increment("failed_subsidiaries")
                 self.failure_registry.add(
-                    filing.cik, filing.accession_number, FailureType.DOCUMENT_ERROR
+                    filing.cik, filing.filename, FailureType.DOCUMENT_ERROR
                 )
 
             except Exception as _:
@@ -276,7 +283,7 @@ class SubsidiaryPipeline(Pipeline):
                 )
                 self.stats.increment("failed_subsidiaries")
                 self.failure_registry.add(
-                    filing.cik, filing.accession_number, FailureType.EXTRACTION_FAILED
+                    filing.cik, filing.filename, FailureType.EXTRACTION_FAILED
                 )
 
             finally:
@@ -314,7 +321,7 @@ class SubsidiaryPipeline(Pipeline):
             )
             self.stats.increment("failed_subsidiaries")
             self.failure_registry.add(
-                filing.cik, filing.accession_number, FailureType.NO_FILING_DIRECTORY
+                filing.cik, filing.filename, FailureType.NO_FILING_DIRECTORY
             )
             return []
         self.sec_client.rate_limit()
@@ -343,7 +350,7 @@ class SubsidiaryPipeline(Pipeline):
                 self.logger.error("Failed to extract PDF content: %s", sec_url)
                 self.stats.increment("failed_subsidiaries")
                 self.failure_registry.add(
-                    filing.cik, filing.accession_number, FailureType.NO_EXHIBIT_CONTENT
+                    filing.cik, filing.filename, FailureType.NO_EXHIBIT_CONTENT
                 )
         return exhibit_content
 
@@ -371,7 +378,7 @@ class SubsidiaryPipeline(Pipeline):
             )
             self.stats.increment("failed_subsidiaries")
             self.failure_registry.add(
-                filing.cik, filing.accession_number, FailureType.NO_EXHIBIT_CONTENT
+                filing.cik, filing.filename, FailureType.NO_EXHIBIT_CONTENT
             )
         return exhibit_content
 

--- a/src/idi_corporate_structure/processor/pipeline.py
+++ b/src/idi_corporate_structure/processor/pipeline.py
@@ -85,6 +85,7 @@ class SubsidiaryPipeline(Pipeline):
     IS_10K = re.compile("10-?K")
     IS_DATE = re.compile("[0-9]{4}-[0-9]{2}-[0-9]{2}")
     TWENTYONE = re.compile("[^0-9]21")
+    IS_OVERFLOW = re.compile(r"-submissions-\d+\.json$")
 
     _INPUT_SAMPLE_SIZE = 10  # TODO: Remove after done testing
     _SUPPORTED_EXHIBIT_EXTENSIONS = frozenset({"HTM", "HTML", "TXT", "PDF"})
@@ -102,18 +103,69 @@ class SubsidiaryPipeline(Pipeline):
         )
         self.rows = []
 
-    def _zip_file_data(self, data: dict, filename: str, cik: str) -> zip | None:
+    def _retrieve_overflow_filings(self, data: dict, cik: str, zf: zipfile.ZipFile) -> tuple[list, list, list, list]:
+        """Retrieve overflow filings from the SEC submissions JSON.
+
+        Args:
+            data: Data to retrieve overflow filings from
+            cik: Identifier of file data was retrieved from
+            zf: Open ZipFile to read from.
+
+        Returns:
+            Tuple of lists of forms, accession numbers, primary documents, and filing dates.
+        """
+        forms = []
+        accession_numbers = []
+        primary_documents = []
+        filing_dates = []
+        for entry in data.get("filings", {}).get("files", []):
+
+            overflow_filename = entry.get("name", "")
+            if not overflow_filename:
+                continue
+
+            if (cik, overflow_filename) in self.failure_registry:
+                self.logger.debug("Skipping overflow file — permanent failure recorded: %s", overflow_filename)
+                self.stats.increment("skipped_filings")
+                continue
+
+            try:
+                with zf.open(overflow_filename) as of:
+                    overflow = json.load(of)
+
+                forms += overflow.get("form", [])
+                accession_numbers += overflow.get("accessionNumber", [])
+                primary_documents += overflow.get("primaryDocument", [])
+                filing_dates += overflow.get("filingDate", [])
+
+            except KeyError:
+                self.logger.error("Overflow file not found: %s", overflow_filename)
+                self.stats.increment("failed_filings")
+                self.failure_registry.add(cik, overflow_filename, failure_type=FailureType.NO_OVERFLOW_FILINGS)
+
+        return forms, accession_numbers, primary_documents, filing_dates
+
+    def _zip_file_data(self, data: dict, filename: str, cik: str, zf: zipfile.ZipFile) -> zip | None:
         """Locate and returned zipped file data.
 
         Args:
             data: Data to retrieve specific file data from
             filename: Name of file data was retrieved from
             cik: Identifier of file data was retrieved from
+            zf: Open ZipFile to read from.
         """
+        # Retrieve recent filings
         forms = data.get("filings", {}).get("recent", {}).get("form", [])
         accession_numbers = data.get("filings", {}).get("recent", {}).get("accessionNumber", [])
         primary_documents = data.get("filings", {}).get("recent", {}).get("primaryDocument", [])
         filing_dates = data.get("filings", {}).get("recent", {}).get("filingDate", [])
+
+        # Retrieve overflow filings
+        o_forms, o_accession_numbers, o_primary_documents, o_filing_dates = self._retrieve_overflow_filings(data, cik, zf)
+        forms.extend(o_forms)
+        accession_numbers.extend(o_accession_numbers)
+        primary_documents.extend(o_primary_documents)
+        filing_dates.extend(o_filing_dates)
 
         if (
             len({len(forms), len(accession_numbers), len(primary_documents), len(filing_dates)})
@@ -131,6 +183,45 @@ class SubsidiaryPipeline(Pipeline):
             return None
 
         return zip(forms, accession_numbers, primary_documents, filing_dates)
+
+    def _process_filings_zip(
+        self,
+        filings_zip: zip,
+        company_data: dict,
+        source_filename: str,
+    ) -> list[Filing]:
+        """Iterate a filings zip and collect 10-K Filing objects.
+
+        Args:
+            filings_zip: zip of (form, accession_number, primary_document, filing_date) tuples.
+            company_data: Dict with cik, name, location keys.
+            source_filename: Filename used for failure registry entries and debug logging.
+
+        Returns:
+            List of Filing objects for 10-K forms only.
+        """
+        filings = []
+        for form, accession_number, primary_document, filing_date in filings_zip:
+            if self.IS_10K.match(form):
+                filings.append(
+                    self._create_filing(
+                        accession_number=accession_number,
+                        primary_document=primary_document,
+                        filing_date=filing_date,
+                        form=form,
+                        company_data=company_data,
+                    )
+                )
+                self.stats.increment("total_filing")
+
+            else:
+                self.logger.debug("Filename: %s skipping non-10K form: %s.", source_filename, form)
+
+        if not filings:
+            self.stats.increment("failed_filings")
+            self.failure_registry.add(company_data["cik"], source_filename, failure_type=FailureType.NO_10K_FILINGS)
+
+        return filings
 
     def _create_filing(
         self,
@@ -187,45 +278,34 @@ class SubsidiaryPipeline(Pipeline):
             List of Filing objects with form data
         """
         filings = []
-        if filename.startswith("CIK") and filename.endswith(".json"):
-            with zf.open(filename) as file:
-                data = json.load(file)
 
-            company_data = {
-                "cik": data.get("cik", ""),
-                "name": data.get("name", ""),
-                "location": data.get("stateOfIncorporation", ""),
-                "filename": filename,
-            }
+        # Overflow files have no company metadata; loaded below with primary file
+        if self.IS_OVERFLOW.search(filename):
+            return filings
 
-            # Skip files that had a permanent failure on a previous run
-            if (company_data["cik"], filename) in self.failure_registry:
-                self.logger.debug("Skipping permanent failure for filing: %s - %s", company_data["cik"], filename)
-                self.stats.increment("skipped_filings")
-                return filings
+        if not (filename.startswith("CIK") and filename.endswith(".json")):
+            return filings
 
-            filings_zip = self._zip_file_data(data, filename, company_data["cik"])
+        with zf.open(filename) as file:
+            data = json.load(file)
 
-            if filings_zip:
-                for form, accession_number, primary_document, filing_date in filings_zip:
-                    if self.IS_10K.match(form):
-                        filings.append(
-                            self._create_filing(
-                                accession_number=accession_number,
-                                primary_document=primary_document,
-                                filing_date=filing_date,
-                                form=form,
-                                company_data=company_data,
-                            )
-                        )
-                        self.stats.increment("total_filing")
+        company_data = {
+            "cik": data.get("cik", ""),
+            "name": data.get("name", ""),
+            "location": data.get("stateOfIncorporation", ""),
+            "filename": filename,
+        }
 
-                    else:
-                        self.logger.debug("Filename: %s skipping non-10K form: %s.", filename, form)
+        # Skip files that had a permanent failure on a previous run
+        if (company_data["cik"], filename) in self.failure_registry:
+            self.logger.debug("Skipping permanent failure for filing: %s - %s", company_data["cik"], filename)
+            self.stats.increment("skipped_filings")
+            return filings
 
-                if not filings:
-                    self.stats.increment("failed_filings")
-                    self.failure_registry.add(company_data["cik"], filename, failure_type=FailureType.NO_10K_FILINGS)
+        # Process filings
+        filings_zip = self._zip_file_data(data, filename, company_data["cik"], zf)
+        if filings_zip:
+            filings.extend(self._process_filings_zip(filings_zip, company_data, filename))
 
         return filings
 
@@ -239,6 +319,7 @@ class SubsidiaryPipeline(Pipeline):
         with open_zip(self.config.input_file, headers=self.sec_client.SEC_HEADERS) as zf:
             namelist = zf.namelist()
             namelist = namelist[: self._INPUT_SAMPLE_SIZE]  # TODO: Remove after done testing
+            namelist = ["CIK0000001750.json"]  # TODO: Remove after done testing
             self.logger.info("Total # of files to process: %d", len(namelist))
 
             for filename in tqdm(namelist):

--- a/src/idi_corporate_structure/processor/pipeline.py
+++ b/src/idi_corporate_structure/processor/pipeline.py
@@ -68,11 +68,9 @@ class Pipeline(ABC):
     def run(self) -> None:
         """Run the pipeline."""
         start_time = datetime.datetime.now()
-        input_data = self.load_input()
-        self.logger.info("Located %d input data items", len(input_data))
 
+        input_data = self.load_input()
         results = self.process(input_data)
-        self.logger.info("Located %d subsidiaries", len(results))
 
         self.save_output(results)
         self.display_stats()
@@ -240,11 +238,16 @@ class SubsidiaryPipeline(Pipeline):
         filings = []
         with open_zip(self.config.input_file, headers=self.sec_client.SEC_HEADERS) as zf:
             namelist = zf.namelist()
+            namelist = namelist[: self._INPUT_SAMPLE_SIZE]  # TODO: Remove after done testing
             self.logger.info("Total # of files to process: %d", len(namelist))
 
-            namelist = namelist[: self._INPUT_SAMPLE_SIZE]  # TODO: Remove after done testing
             for filename in tqdm(namelist):
-                filings.extend(self._parse_file(zf, filename))
+                filings_for_file = self._parse_file(zf, filename)
+                if filings_for_file:
+                    filings.extend(filings_for_file)
+
+        self.logger.info("Located %d filings for %d files", len(filings), len(namelist) - self.stats.skipped_filings)
+        self.logger.info("Skipped %d files", self.stats.skipped_filings)
 
         return filings
 
@@ -440,6 +443,7 @@ class SubsidiaryPipeline(Pipeline):
 
     def process(self, input_list: list[Filing]) -> list[Subsidiary]:
         """Process input filing list to retrieve subsidiary data."""
+        self.logger.info("Located %d subsidiaries", len(input_list))
         # Queues to store exhibit data and subsidiary data
         work_queue = queue.Queue(maxsize=self.config.num_workers * 2)
         result_queue = queue.Queue()
@@ -495,6 +499,7 @@ class SubsidiaryPipeline(Pipeline):
         self.logger.info("=" * 40)
         self.logger.info("  Filings")
         self.logger.info("    Total:    %d", self.stats.total_filing)
+        self.logger.info("    Skipped:  %d", self.stats.skipped_filings)
         self.logger.info("    Failed:   %d", self.stats.failed_filings)
         self.logger.info("  Subsidiaries")
         self.logger.info("    Total:    %d", self.stats.total_subsidiaries)

--- a/src/idi_corporate_structure/processor/types.py
+++ b/src/idi_corporate_structure/processor/types.py
@@ -24,6 +24,7 @@ class Filing:
     primary_document: str
     company_name: str = ""
     location: str = ""
+    filename: str = ""
 
 
 @dataclass
@@ -42,9 +43,7 @@ class PipelineConfig:
         if _is_local(self.input_file) and not pathlib.Path(self.input_file).exists():
             raise FileNotFoundError(f"Input file not found: {self.input_file}")
         if _is_local(self.failure_file) and not pathlib.Path(self.failure_file).parent.exists():
-            raise FileNotFoundError(
-                f"Failure file directory does not exist: {pathlib.Path(self.failure_file).parent}"
-            )
+            pathlib.Path(self.failure_file).parent.mkdir(parents=True, exist_ok=True)
         if _is_local(self.output_file) and not pathlib.Path(self.output_file).parent.exists():
             pathlib.Path(self.output_file).parent.mkdir(parents=True, exist_ok=True)
 

--- a/tests/common/test_failures.py
+++ b/tests/common/test_failures.py
@@ -30,20 +30,20 @@ class TestFailureRegistryAdd:
 
     def test_non_retryable_failure_is_added(self, tmp_path):
         registry = make_registry(tmp_path)
-        registry.add("0001234567", "0001234567-24-000001", FailureType.MISMATCHED_LENGTHS)
+        registry.add(("0001234567", "0001234567-24-000001"), FailureType.MISMATCHED_LENGTHS)
 
         assert ("0001234567", "0001234567-24-000001") in registry
 
     def test_retryable_failure_is_skipped(self, tmp_path):
         registry = make_registry(tmp_path)
-        registry.add("0001234567", "0001234567-24-000001", FailureType.EXTRACTION_FAILED)
+        registry.add(("0001234567", "0001234567-24-000001"), FailureType.EXTRACTION_FAILED)
 
         assert ("0001234567", "0001234567-24-000001") not in registry
 
     def test_duplicate_add_is_idempotent(self, tmp_path):
         registry = make_registry(tmp_path)
-        registry.add("0001234567", "0001234567-24-000001", FailureType.NO_FORM_DATA)
-        registry.add("0001234567", "0001234567-24-000001", FailureType.NO_FORM_DATA)
+        registry.add(("0001234567", "0001234567-24-000001"), FailureType.NO_FORM_DATA)
+        registry.add(("0001234567", "0001234567-24-000001"), FailureType.NO_FORM_DATA)
 
         # Still only one entry
         assert len(registry._entries) == 1
@@ -58,7 +58,7 @@ class TestFailureRegistryAdd:
         ]
         registry = make_registry(tmp_path)
         for i, ft in enumerate(non_retryable):
-            registry.add(f"CIK{i:010d}", f"ACC{i:020d}", ft)
+            registry.add((f"CIK{i:010d}", f"ACC{i:020d}"), ft)
 
         assert len(registry._entries) == len(non_retryable)
 
@@ -70,7 +70,7 @@ class TestFailureRegistryAdd:
         ]
         registry = make_registry(tmp_path)
         for i, ft in enumerate(retryable):
-            registry.add(f"CIK{i:010d}", f"ACC{i:020d}", ft)
+            registry.add((f"CIK{i:010d}", f"ACC{i:020d}"), ft)
 
         assert len(registry._entries) == 0
 
@@ -80,7 +80,7 @@ class TestFailureRegistryPersistence:
 
     def test_flush_writes_entries_to_disk(self, tmp_path):
         registry = make_registry(tmp_path)
-        registry.add("0001234567", "0001234567-24-000001", FailureType.MISMATCHED_LENGTHS)
+        registry.add(("0001234567", "0001234567-24-000001"), FailureType.MISMATCHED_LENGTHS)
         registry.flush()
 
         failure_file = tmp_path / "failures.json"
@@ -92,7 +92,7 @@ class TestFailureRegistryPersistence:
     def test_load_restores_entries_from_disk(self, tmp_path):
         # Write initial registry and flush
         registry = make_registry(tmp_path)
-        registry.add("0001234567", "0001234567-24-000001", FailureType.NO_FORM_DATA)
+        registry.add(("0001234567", "0001234567-24-000001"), FailureType.NO_FORM_DATA)
         registry.flush()
 
         # New registry instance reads from the same file
@@ -102,13 +102,13 @@ class TestFailureRegistryPersistence:
     def test_auto_flush_at_threshold(self, tmp_path):
         registry = make_registry(tmp_path, flush_every=3)
 
-        registry.add("CIK0000000001", "ACC0000000001", FailureType.MISMATCHED_LENGTHS)
-        registry.add("CIK0000000002", "ACC0000000002", FailureType.NO_FORM_DATA)
+        registry.add(("CIK0000000001", "ACC0000000001"), FailureType.MISMATCHED_LENGTHS)
+        registry.add(("CIK0000000002", "ACC0000000002"), FailureType.NO_FORM_DATA)
 
         failure_file = tmp_path / "failures.json"
         assert not failure_file.exists()  # not flushed yet
 
-        registry.add("CIK0000000003", "ACC0000000003", FailureType.NO_10K_FILINGS)
+        registry.add(("CIK0000000003", "ACC0000000003"), FailureType.NO_10K_FILINGS)
 
         # Third add triggers flush
         assert failure_file.exists()
@@ -135,7 +135,7 @@ class TestFailureRegistryPersistence:
 
     def test_reason_is_stored(self, tmp_path):
         registry = make_registry(tmp_path)
-        registry.add("0001234567", "0001234567-24-000001", FailureType.MISMATCHED_LENGTHS)
+        registry.add(("0001234567", "0001234567-24-000001"), FailureType.MISMATCHED_LENGTHS)
         registry.flush()
 
         data = json.loads((tmp_path / "failures.json").read_text())
@@ -154,7 +154,7 @@ class TestFailureRegistryThreadSafety:
         def add_entries(start: int, count: int) -> None:
             try:
                 for i in range(start, start + count):
-                    registry.add(f"CIK{i:010d}", f"ACC{i:020d}", FailureType.MISMATCHED_LENGTHS)
+                    registry.add((f"CIK{i:010d}", f"ACC{i:020d}"), FailureType.MISMATCHED_LENGTHS)
             except Exception as e:
                 errors.append(e)
 

--- a/tests/processor/test_pipeline.py
+++ b/tests/processor/test_pipeline.py
@@ -26,7 +26,9 @@ class TestZipFileData:
             primary_documents=["doc1.htm", "doc2.htm"],
             filing_dates=["2024-09-28", "2024-06-30"],
         )
-        result = pipeline._zip_file_data(data, "CIK0000000001.json", "0000000001")
+        result = pipeline._zip_file_data(
+            data, "CIK0000000001.json", "0000000001", MagicMock(spec=zipfile.ZipFile)
+        )
 
         assert result is not None
         rows = list(result)
@@ -35,7 +37,9 @@ class TestZipFileData:
 
     def test_returns_none_for_empty_data(self, pipeline):
         data = make_cik_json()
-        result = pipeline._zip_file_data(data, "CIK0000000001.json", "0000000001")
+        result = pipeline._zip_file_data(
+            data, "CIK0000000001.json", "0000000001", MagicMock(spec=zipfile.ZipFile)
+        )
 
         assert result is None
 
@@ -46,7 +50,9 @@ class TestZipFileData:
             primary_documents=["doc1.htm", "doc2.htm"],
             filing_dates=["2024-09-28", "2024-06-30"],
         )
-        result = pipeline._zip_file_data(data, "CIK0000000001.json", "0000000001")
+        result = pipeline._zip_file_data(
+            data, "CIK0000000001.json", "0000000001", MagicMock(spec=zipfile.ZipFile)
+        )
 
         assert result is None
 
@@ -57,12 +63,16 @@ class TestZipFileData:
             primary_documents=["doc1.htm"],
             filing_dates=["2024-01-01"],
         )
-        pipeline._zip_file_data(data, "CIK0000000001.json", "0000000001")
+        pipeline._zip_file_data(
+            data, "CIK0000000001.json", "0000000001", MagicMock(spec=zipfile.ZipFile)
+        )
 
         assert pipeline.stats.failed_filings == 1
 
     def test_returns_none_for_missing_filings_key(self, pipeline):
-        result = pipeline._zip_file_data({}, "CIK0000000001.json", "0000000001")
+        result = pipeline._zip_file_data(
+            {}, "CIK0000000001.json", "0000000001", MagicMock(spec=zipfile.ZipFile)
+        )
         assert result is None
 
 
@@ -72,7 +82,12 @@ class TestZipFileData:
 class TestCreateFiling:
     """Tests for SubsidiaryPipeline._create_filing()."""
 
-    _COMPANY_DATA = {"cik": "0000320193", "name": "APPLE INC", "location": "CA"}
+    _COMPANY_DATA = {
+        "cik": "0000320193",
+        "name": "APPLE INC",
+        "location": "CA",
+        "filename": "CIK0000320193.json",
+    }
 
     def test_builds_directory_url(self, pipeline):
         filing = pipeline._create_filing(
@@ -665,7 +680,7 @@ class TestExtractWorker:
         work_queue.join()
 
         spy.assert_called_once_with(
-            sample_filing.cik, sample_filing.accession_number, FailureType.EXTRACTION_FAILED
+            (sample_filing.cik, sample_filing.filename), FailureType.EXTRACTION_FAILED
         )
 
 

--- a/tests/processor/test_types.py
+++ b/tests/processor/test_types.py
@@ -89,17 +89,19 @@ class TestPipelineConfig:
                 output_file=str(tmp_path / "subsidiaries.parquet"),
             )
 
-    def test_raises_when_failure_dir_missing(self, tmp_path):
+    def test_creates_failure_directory_if_missing(self, tmp_path):
         input_zip = tmp_path / "submissions.zip"
         with zipfile.ZipFile(input_zip, "w"):
             pass
 
-        with pytest.raises(FileNotFoundError, match="Failure file directory does not exist"):
-            PipelineConfig(
-                input_file=str(input_zip),
-                failure_file=str(tmp_path / "nonexistent_dir" / "failures.json"),
-                output_file=str(tmp_path / "subsidiaries.parquet"),
-            )
+        failure_file = tmp_path / "nonexistent_dir" / "failures.json"
+        PipelineConfig(
+            input_file=str(input_zip),
+            failure_file=str(failure_file),
+            output_file=str(tmp_path / "subsidiaries.parquet"),
+        )
+
+        assert failure_file.parent.exists()
 
     def test_creates_output_directory_if_missing(self, tmp_path):
         input_zip = tmp_path / "submissions.zip"


### PR DESCRIPTION
# PR: Skip Previously Failed Filings on Re-run

**Branch:** `issue-18-do-not-retry` → `issue-5-save-results`
**Issue:** #18 and #14

---

## Overview

When the pipeline is re-run it previously re-processed every filing from scratch — including ones that permanently failed (e.g. missing exhibit content, no 10-K forms). 

This PR implements the skip logic so that file-level and overflow-level permanent failures recorded in `failures.json` are bypassed immediately on subsequent runs. 

It also fixes a bug where non-10K form rows were incorrectly recorded as permanent file-level failures (causing all files to be silently skipped on the second run), processes SEC submissions overflow files that were previously lost, and makes `FailureRegistry.add()` truly generic by removing domain-specific parameter names.

Bonus: Update to the progress bar to better capture processing work completed.

---

## Changes

### Skip permanent failures on re-run (`73450a0`)

- `_parse_file()` checks `(cik, filename) in self.failure_registry` before any I/O and returns `[]` immediately for files with a recorded permanent failure; increments `skipped_filings`

### Fix non-10K form tracking (`2e49600`)

- Removed `failed_filings` increment and `failure_registry.add()` from the per-row `else` branch inside the form loop
- `NO_10K_FILINGS` is now recorded once per file, only when the file contains zero 10-K forms at all, after the loop completes

### Process SEC submissions overflow files (`dbccd9b`)

- Companies with large filing histories split data across `CIK{cik}-submissions-NNN.json` overflow files; these have a flat structure with no `cik`/`name` fields and were previously silently dropped
- `_retrieve_overflow_filings()` new helper reads each overflow file referenced in `filings.files`, appends its four arrays (`form`, `accessionNumber`, `primaryDocument`, `filingDate`) to the primary file's lists before validation and zipping

### Make `FailureRegistry.add()` generic (`fb17d95`)

- `add(cik: str, accession_number: str, failure_type)` → `add(key: tuple[str, ...], failure_type)` — removes corporate-structure-specific parameter names so the registry can be reused by any processor
- `load()` and `save()` updated to use `" ".join(e)` for reason dict keys (forward-compatible with any key length; produces identical output for existing 2-element entries)

---

## Test results

### Unit tests

All 129 unit tests pass with no failures.

```
============================= 129 passed in 0.17s ==============================
```

All lint and formatting pass.