### PR TITLE
Update README and docstrings, type annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.egg-info
 .claude
 .venv
+logs/

--- a/README.md
+++ b/README.md
@@ -56,16 +56,17 @@ AWS credentials are required only if using S3 paths for input or output.
 ### Run
 
 ```bash
-uv run python -m idi_corporate_structure.processor.pipeline
+uv run python3 -m src.idi_corporate_structure.processor.orchestrator \
+    --input-file "/local/input/submissions.zip" \
+    --output-file "/local/output/subsidiaries.parquet" \
+    --failure-file "/local/failures/failures.json" \
+    --openai-api-key "sk-proj-xxxxxxxxxxxxx" \
+    --rate-limit 0.2 \
+    --num-workers 10
 ```
 
-The `submissions.zip` bulk data file is available from SEC EDGAR:
-
-```
-https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip
-```
-
-And can be read in via HTTP or local disk.
+- To read the `submissions.zip` file in via HTTP from SEC EDGAR, pass the following URL into the `--input-file` argument:
+    - `https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip`
 
 ### Configuration Reference
 
@@ -75,8 +76,74 @@ And can be read in via HTTP or local disk.
 | `output_file` | — | Required. Path for Parquet output (local or `s3://`) |
 | `failure_file` | — | Required. Path to failures JSON; parent directory created if missing |
 | `failure_flush_every` | `50` | Write failures to disk after every N new entries |
-| `rate_limit` | `0.1` | Seconds between SEC HTTP requests (SEC limit: 10 req/s) |
+| `rate_limit` | `0.2` | Seconds between SEC HTTP requests (SEC limit: 10 req/s) |
 | `num_workers` | `10` | Number of concurrent GPT extraction worker threads |
+
+---
+
+## Container Usage
+
+The pipeline ships with a multi-stage Dockerfile and Docker Compose files for running the orchestrator in a container.
+
+### Files
+
+| File | Purpose |
+|---|---|
+| `dockerfiles/Dockerfile.orchestrator` | Multi-stage `python:3.13-slim` image; non-root `pipeline` user |
+| `compose.yml` | Service definition; pulls image from registry |
+| `compose.override.yml` | Adds `build:` block for local development; merged automatically by `docker compose` |
+
+### Environment Variables
+
+All required variables must be set before running. Optional variables fall back to the listed defaults.
+
+#### Required
+
+| Variable | Description |
+|---|---|
+| `OPENAI_API_KEY` | OpenAI API key for GPT extraction |
+| `INPUT_MOUNT_SOURCE` | Host directory containing the input file (e.g. `/data/input`) |
+| `INPUT_FILE` | Container-side path to the input file (e.g. `/data/input/submissions.zip`); can be an `https://` URL instead of a local path, in which case `INPUT_MOUNT_SOURCE` is unused |
+| `OUTPUT_MOUNT_SOURCE` | Host directory for Parquet output (e.g. `/data/output`) |
+| `FAILURE_MOUNT_SOURCE` | Host directory for failures JSON (e.g. `/data/failures`) |
+| `LOG_DIR` | Host directory for log files (e.g. `/data/logs`) |
+
+#### Optional
+
+| Variable | Default | Description |
+|---|---|---|
+| `OUTPUT_FILE` | `/data/output/output.parquet` | Container-side path for Parquet output |
+| `FAILURE_FILE` | `/data/failures/failures.json` | Container-side path for failures JSON |
+| `RATE_LIMIT` | `0.2` | Seconds between SEC HTTP requests |
+| `NUM_WORKERS` | `10` | Number of concurrent GPT extraction worker threads |
+| `INPUT_SAMPLE_SIZE` | `0` | Limit input to N files for testing (`0` = no limit) |
+| `AWS_REGION` | `us-east-2` | AWS region for S3 and CloudWatch |
+| `CLOUDWATCH_LOGS_ENABLED` | `false` | Enable CloudWatch log shipping |
+| `ORCHESTRATOR_IMAGE` | `ghcr.io/dsi-clinic/idi-corporate-structure-orchestrator:latest` | Image to pull on EC2 (ignored when building locally) |
+
+### Run
+
+**Local — build from source and run:**
+
+```bash
+export OPENAI_API_KEY="sk-proj-xxxxxxxxxxxxx"
+export INPUT_MOUNT_SOURCE="/path/to/input"       # must contain submissions.zip
+export OUTPUT_MOUNT_SOURCE="/path/to/output"
+export FAILURE_MOUNT_SOURCE="/path/to/failures"
+export LOG_DIR="/path/to/logs"
+
+docker compose up --build orchestrator
+```
+
+`compose.override.yml` is merged automatically when running locally, which adds the `build:` block so the image is built from source rather than pulled.
+
+**Detached (background):**
+
+```bash
+docker compose up -d --build orchestrator
+docker compose logs -f orchestrator   # tail logs
+docker compose down                   # stop
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # IDI Corporate Structure Pipeline
 
-> [DRAFT in progress]
-
 Automated pipeline for extracting subsidiary information from SEC 10-K filings (Exhibit 21) and building hierarchical corporate structure trees.
 
 ## Pipeline Overview
 
 Each run performs three stages:
 
-1. **Collection** — parse `submissions.zip` from SEC EDGAR bulk data; extract all 10-K filing metadata (CIK, accession number, filing date, exhibit URLs)
+1. **Collection** — parse `submissions.zip` from SEC EDGAR bulk data; extract all 10-K filing metadata (CIK, accession number, filing date, exhibit URLs); output `Filing` records
 2. **Retrieval** — fetch each filing's directory index from SEC EDGAR; locate and download Exhibit 21 (Subsidiaries of the Registrant)
-3. **Extraction** — pass exhibit content to GPT-4 to parse subsidiary names and incorporation locations; output structured `Subsidiary` records
+3. **Extraction** — pass exhibit content to GPT to parse subsidiary names and incorporation locations; output structured `Subsidiary` records
 
 Processing tracks permanent failures to disk so interrupted runs do not re-attempt filings that will always fail.
 
 ### Output Layout
 
 ```
-{output_dir}/
-  subsidiaries.csv     parent_cik, name, location, filing_date, form_type, accession_number, exhibit_url # This is TBD
-  failures/
-    failures.json      permanent failures keyed by (cik, accession_number)
+output/
+  # Parquet — columns: parent_cik, name, location, filing_date, form_type, accession_number, exhibit_url, date_added
+  {output_file}
+failures/
+  # permanent failures keyed by (cik, accession_number)
+  failures.json
 ```
 
 Paths support local directories or S3 URLs (`s3://bucket/path`).
@@ -29,11 +29,16 @@ Paths support local directories or S3 URLs (`s3://bucket/path`).
 
 ## Quick Start
 
+### Prerequisites
+
+- Python >= 3.13
+- [uv](https://docs.astral.sh/uv/) package manager
+
 ### Installation
 
 ```bash
 uv sync              # Production
-uv sync --all-groups # Development (includes tests)
+uv sync --all-groups # Development (includes tests and linting tools)
 ```
 
 ### Credentials
@@ -51,18 +56,7 @@ AWS credentials are required only if using S3 paths for input or output.
 ### Run
 
 ```bash
-uv run python -m src.idi_corporate_structure.processor.pipeline
-```
-
-Configure the run by editing the `PipelineConfig` block at the bottom of `pipeline.py`:
-
-```python
-config = PipelineConfig(
-    input_file  = "path/to/submissions.zip",   # local path or s3:// or https://
-    failure_file= "path/to/failures.json",
-    rate_limit  = 0.12,                        # seconds between SEC requests (~8 req/s)
-    num_workers = 10,                          # concurrent GPT extraction threads
-)
+uv run python -m idi_corporate_structure.processor.pipeline
 ```
 
 The `submissions.zip` bulk data file is available from SEC EDGAR:
@@ -71,15 +65,58 @@ The `submissions.zip` bulk data file is available from SEC EDGAR:
 https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip
 ```
 
+And can be read in via HTTP or local disk.
+
 ### Configuration Reference
 
 | Field | Default | Description |
 |---|---|---|
 | `input_file` | — | Required. Path to `submissions.zip` (local, `s3://`, or `https://`) |
-| `failure_file` | — | Required. Path to failures JSON; parent directory must exist |
+| `output_file` | — | Required. Path for Parquet output (local or `s3://`) |
+| `failure_file` | — | Required. Path to failures JSON; parent directory created if missing |
 | `failure_flush_every` | `50` | Write failures to disk after every N new entries |
 | `rate_limit` | `0.1` | Seconds between SEC HTTP requests (SEC limit: 10 req/s) |
 | `num_workers` | `10` | Number of concurrent GPT extraction worker threads |
+
+---
+
+## Data Flow
+
+The pipeline walks the SEC EDGAR data hierarchy one level at a time, from the bulk submissions archive down to individual exhibit documents:
+
+```
+submissions.zip  (SEC EDGAR bulk data — one JSON blob per CIK)
+  │
+  │  parse per-CIK JSON, filter to 10-K form type
+  ▼
+10-K Filing  (CIK, accession number, filing date)
+  │
+  │  GET https://www.sec.gov/Archives/edgar/data/{CIK}/{accession_number}/index.json
+  ▼
+10-K Directory Index  (list of all documents in the filing)
+  │
+  │  locate Exhibit 21 entry by document type / filename pattern
+  ▼
+Exhibit 21 Document  (HTML, plain text, or PDF)
+  │
+  │  download and extract text (PDF → pdfplumber)
+  ▼
+Exhibit Content  (raw text listing subsidiaries)
+  │
+  │  POST to OpenAI with structured JSON schema
+  ▼
+GPT Extraction  (gpt-4.1-nano, structured output)
+  │
+  │  parse response into Subsidiary records
+  ▼
+Subsidiaries List  (name, location, parent CIK, accession number, …)
+  │
+  │  deduplicate, append metadata, write via pandas
+  ▼
+Parquet Output  ({output_file})
+```
+
+Each filing that cannot be processed (missing exhibit, empty content, document too long, etc.) is recorded in `failures.json` as a permanent failure and skipped on subsequent runs.
 
 ---
 
@@ -105,28 +142,80 @@ pipeline.py
                     results_queue.get()  ← accumulates Subsidiary records
 ```
 
-**Producer-consumer design**: The SEC fetcher runs serially on the main thread (respecting EDGAR's 10 req/s rate limit). Exhibit content is pushed onto a bounded `queue.Queue(maxsize=num_workers * 2)`, which blocks the producer if workers fall behind. GPT extraction runs concurrently across `num_workers` daemon threads, draining the queue as fast as OpenAI responds. The two stages overlap — SEC fetching continues while earlier exhibits are being summarized.
+**Producer-consumer design**:
 
-**Resumability**: `FailureRegistry` persists non-retryable failures to disk after every `failure_flush_every` entries. On re-run, filings whose failures are classified as permanent (e.g. `no_10k_filings`, `no_exhibit_content`) are skipped without making network requests.
+- The SEC fetcher runs serially on the main thread (respecting EDGAR's 10 req/s rate limit).
+- Exhibit content is pushed onto a bounded `queue.Queue(maxsize=num_workers * 2)`, which blocks the producer if workers fall behind.
+- GPT extraction runs concurrently across `num_workers` daemon threads, draining the queue as fast as OpenAI responds.
+- The two stages overlap — SEC fetching continues while earlier exhibits are being summarized.
 
-**Common modules** (`src/idi_corporate_structure/common/`):
+**Resumability**:
+
+-`FailureRegistry` persists non-retryable failures to disk after every `failure_flush_every` entries. On re-run, filings whose failures are classified as permanent are skipped without making network requests.
+
+### Modules
+
+**Common** (`src/idi_corporate_structure/common/`):
 
 | Module | Purpose |
 |---|---|
-| `api.py` | SEC, LSEG, and Geonames API clients with retry logic |
-| `failures.py` | Permanent-failure registry (do-not-retry) |
-| `logs.py` | Structured logging with optional CloudWatch integration |
-| `storage.py` | JSON load/save (local + S3 + HTTPS) |
+| `api.py` | `ApiClient` base class (retries, rate limiting); `SecClient` for SEC EDGAR; `OpenAiClient` for GPT extraction |
+| `failures.py` | `FailureRegistry` — persists permanent failures to JSON on disk; `FailureClassifier` abstract base |
+| `logs.py` | Structured logging setup with optional CloudWatch (`watchtower`) integration |
+| `storage.py` | `load_json`/`save_json` and `open_zip` supporting local, `s3://`, and `https://` paths |
+
+**Processor** (`src/idi_corporate_structure/processor/`):
+
+| Module | Purpose |
+|---|---|
+| `types.py` | `Filing`, `Subsidiary`, `PipelineConfig`, and `PipelineStats` dataclasses |
+| `extractor.py` | `GptExtractor` — calls OpenAI with a structured JSON schema to parse subsidiary names and locations from exhibit text |
+| `failures.py` | `FailureType` enum and `CorporateStructureFailureClassifier` (maps HTTP responses to retryable vs permanent failures) |
+| `pipeline.py` | `SubsidiaryPipeline` — orchestrates collection, retrieval, and extraction; deduplicates and writes Parquet output |
 
 ### Failure Types
 
 | Type | Retryable | Description |
 |---|---|---|
-| `mismatched_lengths` | No | Filing arrays have unequal lengths |
+| `mismatched_lengths` | No | Parallel filing arrays have unequal lengths |
 | `no_form_data` | No | Filing arrays are empty |
 | `no_10k_filings` | No | CIK has no 10-K forms |
+| `no_overflow_filings` | No | CIK has no overflow filing entries |
 | `no_filing_directory` | No | SEC returned no directory listing for the filing |
 | `no_exhibit_content` | No | Exhibit URL returned no content |
+| `document_error` | No | Exhibit document is too long to process |
 | `extraction_failed` | Yes | GPT returned no subsidiary data |
 | `api_error` | Yes | Transient HTTP failure |
 | `rate_limit` | Yes | SEC 429 — retried with backoff |
+
+---
+
+## Development & Contributing
+
+Install all dependency groups (includes `dev` tools: pytest, ruff):
+
+```bash
+uv sync --all-groups
+```
+
+### Tests
+
+```bash
+uv run pytest
+```
+
+### Linting & Formatting
+
+```bash
+uv run ruff check .    # lint
+uv run ruff format .   # format
+```
+
+### Code Style
+
+| Rule | Value |
+|---|---|
+| Line length | 100 characters |
+| Docstring convention | Google (`pydocstyle`) |
+| Type annotations | Required on all public functions and classes |
+| String quotes | Double-quoted (ruff `Q` ruleset) |

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -1,0 +1,9 @@
+# Local development override — automatically merged by `docker compose` when running locally.
+# Adds build blocks so services are built from source instead of pulled from the registry.
+# On EC2, only compose.yml is used (no build blocks, pulls from ECR via ORCHESTRATOR_IMAGE).
+# See: https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/
+services:
+  orchestrator:
+    build:
+      context: .
+      dockerfile: dockerfiles/Dockerfile.orchestrator

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,46 @@
+services:
+
+  # ---------------------------------------------------------------------------
+  # Corporate structure pipeline
+  # ---------------------------------------------------------------------------
+  orchestrator:
+    image: ${ORCHESTRATOR_IMAGE:-ghcr.io/dsi-clinic/idi-corporate-structure-orchestrator:latest}
+    container_name: idi-corporate-structure-orchestrator
+
+    environment:
+      - AWS_REGION=${AWS_REGION:-us-east-2}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:?OPENAI_API_KEY is required}
+      - INPUT_FILE=${INPUT_FILE:-/data/input/submissions.zip}
+      - OUTPUT_FILE=${OUTPUT_FILE:-/data/output/subsidiaries.parquet}
+      - FAILURE_FILE=${FAILURE_FILE:-/data/failures/failures.json}
+      - RATE_LIMIT=${RATE_LIMIT:-0.2}
+      - NUM_WORKERS=${NUM_WORKERS:-10}
+      - CLOUDWATCH_LOGS_ENABLED=${CLOUDWATCH_LOGS_ENABLED:-false}
+      - INPUT_SAMPLE_SIZE=${INPUT_SAMPLE_SIZE:-0}
+
+    volumes:
+      - ${INPUT_MOUNT_SOURCE:?INPUT_MOUNT_SOURCE is required (host directory containing the input file)}:/data/input:ro
+      - ${OUTPUT_MOUNT_SOURCE:?OUTPUT_MOUNT_SOURCE is required (host directory for output files)}:/data/output
+      - ${FAILURE_MOUNT_SOURCE:?FAILURE_MOUNT_SOURCE is required (host directory for failure files)}:/data/failures
+      - ${LOG_DIR:?LOG_DIR is required (host directory for log files)}:/logs
+
+    entrypoint: ["/bin/sh", "-c"]
+    command: >
+      "python -m idi_corporate_structure.processor.orchestrator
+      --input-file $${INPUT_FILE:-/data/input/submissions.zip}
+      --output-file $${OUTPUT_FILE:-/data/output/subsidiaries.parquet}
+      --failure-file $${FAILURE_FILE:-/data/failures/failures.json}
+      --openai-api-key ${OPENAI_API_KEY}
+      --rate-limit ${RATE_LIMIT:-0.2}
+      --num-workers ${NUM_WORKERS:-10}
+      2>&1 | tee /logs/orchestrator_$(date +%Y%m%d_%H%M%S).log"
+
+    # Retry up to 3 times if the process exits with a non-zero code
+    restart: on-failure
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+        compress: "true"

--- a/dockerfiles/Dockerfile.orchestrator
+++ b/dockerfiles/Dockerfile.orchestrator
@@ -1,0 +1,51 @@
+# Multi-stage build for efficient image size
+FROM python:3.13-slim AS builder
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy dependency files
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+
+# Install Python dependencies
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -e .
+
+# Final stage - minimal runtime image
+FROM python:3.13-slim
+
+# Create non-root user for security
+RUN useradd -m -u 1000 pipeline && \
+    mkdir -p /data/input /data/output /data/failures /logs && \
+    chown -R pipeline:pipeline /data /logs
+
+# Set working directory
+WORKDIR /app
+
+# Copy installed packages from builder
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+COPY --from=builder /app /app
+
+# Switch to non-root user
+USER pipeline
+
+# Create volume mount points
+VOLUME ["/data/input", "/data/output", "/data/failures", "/logs"]
+
+# Set Python unbuffered mode for real-time logging
+ENV PYTHONUNBUFFERED=1
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import sys; sys.exit(0)"
+
+# Default command (can be overridden in compose)
+ENTRYPOINT ["python", "-m", "idi_corporate_structure.processor.orchestrator"]
+CMD ["--help"]

--- a/src/idi_corporate_structure/common/api.py
+++ b/src/idi_corporate_structure/common/api.py
@@ -133,26 +133,31 @@ class ApiClient(ABC):
     def _query_with_error_handling(
         self,
         url: str,
-        data: str | dict = None,
-        params: dict = None,
-        headers: dict = None,
+        data: str | dict | None = None,
+        params: dict | None = None,
+        headers: dict | None = None,
         method: Literal["get", "post"] = "get",
         return_json: bool = True,
         return_bytes: bool = False,
     ) -> dict[str, Any]:
-        """Query an endpoint with error handling.
+        """Query an endpoint with error handling, capturing errors in the return value.
+
+        On success the returned dict contains ``status_code``, ``url``, and ``data`` keys.
+        On failure an ``error`` key is added; HTTP errors also include ``status_code``.
+        Exceptions are never re-raised — callers should check for the ``error`` key.
 
         Args:
             url: The URL to query.
-            data: The data to post to the API.
-            params: The parameters to pass to the API.
-            headers: The headers to pass to the API.
-            method: The method to use to query the API.
-            return_json: If True, parse response as JSON; otherwise return raw text.
-            return_bytes: If True, return raw response bytes (overrides return_json).
+            data: The data to post to the API. Only used when ``method`` is ``"post"``.
+            params: Query-string parameters to pass to the API.
+            headers: HTTP headers to pass to the API.
+            method: HTTP verb to use — ``"get"`` or ``"post"``.
+            return_json: If True, parse the response body as JSON; otherwise return raw text.
+            return_bytes: If True, return raw response bytes (overrides ``return_json``).
 
         Returns:
-            The data from the API.
+            Dict with ``status_code``, ``url``, and ``data`` keys on success.
+            On error, ``error`` is added and ``data`` may be absent.
         """
         response, error, error_exc = None, None, None
         try:
@@ -196,8 +201,20 @@ class ApiClient(ABC):
         return response_data
 
     @abstractmethod
-    def query_endpoint(self, **kwargs) -> dict[str, Any]:
-        """Query an endpoint."""
+    def query_endpoint(self, **kwargs: object) -> dict[str, Any]:
+        """Query the API endpoint specific to this client.
+
+        Subclasses define the exact positional/keyword parameters relevant to their
+        endpoint. The return dict follows the ``_query_with_error_handling`` contract:
+        ``status_code``, ``url``, and ``data`` on success; ``error`` on failure.
+
+        Args:
+            **kwargs: Endpoint-specific arguments defined by each subclass.
+
+        Returns:
+            Dict with ``status_code``, ``url``, and ``data`` on success, plus ``error``
+            on failure.
+        """
         ...
 
 
@@ -206,14 +223,15 @@ class LsegEntitySearch(ApiClient):
 
     ENTITY_SEARCH_URL = "https://api-eit.refinitiv.com/permid/search"
 
-    def query_endpoint(self, params: dict) -> dict:
+    def query_endpoint(self, params: dict) -> dict[str, Any]:
         """Query the LSEG Entity Search API.
 
         Args:
-            params: The parameters to pass to the API.
+            params: Query parameters to pass to the entity search endpoint.
 
         Returns:
-            The data from the API.
+            Dict with ``status_code``, ``url``, and ``data`` on success, plus ``error``
+            on failure.
         """
         headers = {
             "X-AG-Access-Token": self.api_key,
@@ -230,14 +248,15 @@ class LsegRecordMatch(ApiClient):
 
     RECORD_MATCH_URL = "https://api-eit.refinitiv.com/permid/match"
 
-    def query_endpoint(self, csv_data: str) -> dict:
+    def query_endpoint(self, csv_data: str) -> dict[str, Any]:
         """Query the LSEG Record Match API.
 
         Args:
-            csv_data: The CSV data to search for.
+            csv_data: CSV-formatted string of records to match against LSEG entity data.
 
         Returns:
-            The data from the API.
+            Dict with ``status_code``, ``url``, and ``data`` on success, plus ``error``
+            on failure.
         """
         headers = {
             "accept": "application/json",
@@ -255,14 +274,15 @@ class LsegRecordMatch(ApiClient):
 class LSEGEntityLookup(ApiClient):
     """API client for the LSEG Entity Lookup API."""
 
-    def query_endpoint(self, permid_url: str) -> dict:
+    def query_endpoint(self, permid_url: str) -> dict[str, Any]:
         """Query the LSEG Entity Lookup API.
 
         Args:
-            permid_url: The PermID URL to lookup.
+            permid_url: Full PermID URL to look up (e.g. ``https://permid.org/1-...``).
 
         Returns:
-            The data from the API.
+            Dict with ``status_code``, ``url``, and ``data`` on success, plus ``error``
+            on failure.
         """
         headers = {
             "X-AG-Access-Token": self.api_key,
@@ -289,11 +309,19 @@ class GeonamesApi(ApiClient):
         super().__init__(api_key=api_key)
         self.geonames_user = geonames_user
 
-    def query_endpoint(self, geoname_url: str) -> dict:
+    def query_endpoint(self, geoname_url: str) -> dict[str, Any]:
         """Query the Geonames API.
 
+        Extracts the numeric geoname ID from ``geoname_url`` and fetches the
+        corresponding record from the Geonames REST service.
+
         Args:
-            geoname_url: The Geonames URL to look up (e.g. http://sws.geonames.org/6252001/).
+            geoname_url: Geonames linked-data URL containing the numeric ID
+                (e.g. ``http://sws.geonames.org/6252001/``).
+
+        Returns:
+            Dict with ``status_code``, ``url``, and ``data`` on success, plus ``error``
+            on failure.
         """
         # Extract geoname ID from URL (e.g., http://sws.geonames.org/6252001/)
         geoname_id = geoname_url.rstrip("/").split("/")[-1]
@@ -321,16 +349,17 @@ class SecClient(ApiClient):
 
     def query_endpoint(
         self, sec_url: str, return_json: bool = True, return_bytes: bool = False
-    ) -> dict:
-        """Query SEC API endpoint.
+    ) -> dict[str, Any]:
+        """Query a SEC EDGAR endpoint with the required User-Agent header.
 
         Args:
-            sec_url: URL to query.
+            sec_url: Full SEC EDGAR URL to query.
             return_json: If True, parse response as JSON; otherwise return raw text.
-            return_bytes: If True, return raw response bytes (overrides return_json).
+            return_bytes: If True, return raw response bytes (overrides ``return_json``).
 
         Returns:
-            Response dict with status_code, url, and data keys.
+            Dict with ``status_code``, ``url``, and ``data`` on success, plus ``error``
+            on failure.
         """
         return self._query_with_error_handling(
             url=sec_url,
@@ -357,17 +386,21 @@ class OpenAiClient(ApiClient):
 
     def query_endpoint(
         self,
-        data: str | dict = None,
+        data: str | dict | None = None,
         return_json: bool = True,
-    ) -> dict:
-        """Query OpenAI API endpoint.
+    ) -> dict[str, Any]:
+        """Query the OpenAI chat completions endpoint.
+
+        If ``data`` is a dict it is serialized to JSON before being sent.
 
         Args:
-            data: The data to post to the API.
+            data: Request payload as a JSON string or a dict. Pass ``None`` to send
+                an empty body.
             return_json: If True, parse response as JSON; otherwise return raw text.
 
         Returns:
-            Response dict with status_code, url, and data keys.
+            Dict with ``status_code``, ``url``, and ``data`` on success, plus ``error``
+            on failure.
         """
         headers = {
             "Content-Type": "application/json",

--- a/src/idi_corporate_structure/common/failures.py
+++ b/src/idi_corporate_structure/common/failures.py
@@ -18,7 +18,7 @@ class FailureClassifier(ABC):
 
     @property
     @abstractmethod
-    def do_not_retry(self) -> frozenset:
+    def do_not_retry(self) -> frozenset[StrEnum]:
         """Return the set of failure types that should not be retried."""
         ...
 
@@ -34,7 +34,7 @@ class FailureClassifier(ABC):
         return failure_type not in self.do_not_retry
 
     @abstractmethod
-    def classify_from_response(self, response: dict, **kwargs) -> StrEnum:
+    def classify_from_response(self, response: dict, **kwargs: object) -> StrEnum:
         """Classify a failure from an API response.
 
         Args:
@@ -70,7 +70,19 @@ class FailureRegistry:
         self.load()
 
     def load(self) -> None:
-        """Load entries from the persistence file."""
+        """Load persisted failure entries from disk into memory.
+
+        If the file does not exist (locally or on S3), the registry is initialised
+        as empty. A ``json.JSONDecodeError`` from a corrupt file is silently caught
+        and the registry is reset to empty so the pipeline can continue.
+
+        Returns:
+            None
+
+        Raises:
+            botocore.exceptions.ClientError: If an S3 error other than ``NoSuchKey``
+                occurs when reading the persistence file.
+        """
         if not self.file_path or (
             not self.file_path.startswith("s3://") and not pathlib.Path(self.file_path).exists()
         ):
@@ -101,7 +113,15 @@ class FailureRegistry:
                 self._reasons[entry] = reasons_data[key]
 
     def save(self) -> None:
-        """Persist entries to the file."""
+        """Persist current failure entries and reasons to the configured file path.
+
+        Writes entries as a JSON object with ``entries`` (list of lists) and
+        ``reasons`` (dict keyed by space-joined entry tuples) keys. If
+        ``file_path`` is empty the call is a no-op.
+
+        Returns:
+            None
+        """
         if not self.file_path:
             return
 

--- a/src/idi_corporate_structure/common/logs.py
+++ b/src/idi_corporate_structure/common/logs.py
@@ -81,7 +81,6 @@ def get_logger(name: str, level: int = logging.INFO) -> logging.Logger:
 
     Args:
         name: The logger name.
-
         level: The initial level. Defaults to 20 ("INFO").
 
     Returns:

--- a/src/idi_corporate_structure/common/storage.py
+++ b/src/idi_corporate_structure/common/storage.py
@@ -22,10 +22,26 @@ def _empty_for_return_type(return_type: str) -> dict | list:
 
 
 def load_json(file_path: str, return_type: str = "dict") -> dict | list:
-    """Load a JSON file from the given path.
+    """Load a JSON file from a local path or S3 URL.
 
-    Supports local paths and s3:// URLs.
-    Returns empty dict/list if file does not exist; raises on other errors.
+    Supports any path scheme understood by ``smart_open`` (local, ``s3://``).
+    Missing files — locally absent or absent on S3 — are treated as empty and
+    return the appropriate empty container instead of raising.
+
+    Args:
+        file_path: Local filesystem path or ``s3://bucket/key`` URL of the JSON file.
+        return_type: Expected top-level type of the JSON document — ``"dict"`` or
+            ``"list"``. Controls the empty value returned when the file is absent.
+            Raises ``ValueError`` for any other value.
+
+    Returns:
+        Parsed JSON content as a ``dict`` or ``list``. Returns an empty ``dict`` or
+        ``list`` (per ``return_type``) when the file does not exist.
+
+    Raises:
+        ValueError: If ``return_type`` is not ``"dict"`` or ``"list"``.
+        botocore.exceptions.ClientError: If an S3 error other than ``NoSuchKey`` occurs.
+        json.JSONDecodeError: If the file exists but contains invalid JSON.
     """
     try:
         with smart_open.open(file_path) as f:
@@ -70,8 +86,19 @@ def open_zip(file_path: str, headers: dict | None = None) -> Iterator[zipfile.Zi
     HTTPS requires the server to support range requests (Accept-Ranges: bytes).
 
     Args:
-        file_path: The path to the JSON file.
-        headers: Optional HTTP headers passed as transport params (e.g. User-Agent for SEC EDGAR).
+        file_path: Path to the ZIP file — local filesystem path, ``s3://`` URL, or
+            ``https://`` URL. HTTPS requires the server to support range requests
+            (``Accept-Ranges: bytes``).
+        headers: Optional HTTP headers passed as transport params (e.g. ``User-Agent``
+            for SEC EDGAR). Ignored for local and S3 paths.
+
+    Yields:
+        An open ``zipfile.ZipFile`` object. The underlying stream is closed
+        automatically when the context manager exits.
+
+    Raises:
+        zipfile.BadZipFile: If the file is not a valid ZIP archive.
+        OSError: If the file cannot be opened or read.
     """
     tp = {"headers": headers} if headers else {}
     with smart_open.open(file_path, "rb", transport_params=tp) as f:

--- a/src/idi_corporate_structure/processor/extractor.py
+++ b/src/idi_corporate_structure/processor/extractor.py
@@ -55,6 +55,20 @@ class GptExtractor(Extractor):
     """.strip()
 
     def _get_request_data_json(self, document: str) -> dict:
+        """Build the OpenAI chat completions request payload for subsidiary extraction.
+
+        Constructs a structured-output request that instructs the model to parse
+        a subsidiary table from ``document`` and return a JSON object conforming
+        to the ``list_of_subsidiaries`` schema.
+
+        Args:
+            document: Raw exhibit text (Markdown or plain text) to send as the user
+                message.
+
+        Returns:
+            Dict ready to be serialized and posted to the OpenAI API, containing
+            ``model``, ``messages``, and ``response_format`` keys.
+        """
         return {
             "model": "gpt-4.1-nano",
             "messages": [
@@ -93,14 +107,20 @@ class GptExtractor(Extractor):
             },
         }
 
-    def _summarize(self, document: str) -> str:
-        """Summarize the document using GPT.
+    def _summarize(self, document: str) -> dict:
+        """Send the document to GPT and return the parsed subsidiary data.
 
         Args:
-            document: The document to summarize.
+            document: Raw exhibit text to pass to the model.
 
         Returns:
-            A dictionary of the summarized document.
+            Parsed JSON response from the model as a dict with a ``"subsidiaries"``
+            key containing a list of ``{"name": ..., "in": ...}`` objects.
+
+        Raises:
+            DocumentError: If the API returns a 400-level status code, indicating
+                the document itself is malformed or too long.
+            RuntimeError: If the API returns any other error.
         """
         post_data = self._get_request_data_json(document)
         response = self._OPENAI_CLIENT.query_endpoint(post_data)
@@ -114,7 +134,26 @@ class GptExtractor(Extractor):
         return json.loads(content)
 
     def extract(self, filing: Filing, document: dict) -> list[Subsidiary]:
-        """Use GPT to extract structured subsidiary data from a single document."""
+        """Extract subsidiaries from an exhibit document using GPT.
+
+        Sends the document text to the OpenAI API and maps each item in the
+        returned ``"subsidiaries"`` list to a :class:`Subsidiary` dataclass,
+        inheriting parent metadata from ``filing``.
+
+        Args:
+            filing: The SEC filing the exhibit belongs to. Provides parent company
+                metadata (CIK, name, location, dates).
+            document: Dict with ``"url"`` (exhibit URL) and ``"data"`` (exhibit text)
+                keys.
+
+        Returns:
+            List of :class:`Subsidiary` objects extracted from the document.
+
+        Raises:
+            DocumentError: If GPT rejects the document (e.g. content too long or
+                malformed).
+            RuntimeError: If the OpenAI API returns any other error.
+        """
         summary = self._summarize(document["data"])
         return [
             Subsidiary(

--- a/src/idi_corporate_structure/processor/extractor.py
+++ b/src/idi_corporate_structure/processor/extractor.py
@@ -2,7 +2,6 @@
 
 # Standard imports
 import json
-import os
 from abc import ABC, abstractmethod
 
 # Application imports
@@ -37,7 +36,6 @@ class GptExtractor(Extractor):
     """Extracts subsidiaries from a single exhibit document using GPT."""
 
     _DOCUMENT_ERROR_STATUS_CODE = 400
-    _OPENAI_CLIENT = OpenAiClient(api_key=os.environ.get("OPENAI_API_KEY", ""))
     _SYSTEM_PROMPT = """
     Given a table of a company's subsidiaries (in Markdown or raw text, previously converted from PDF), format them as a JSON, like
 
@@ -53,6 +51,10 @@ class GptExtractor(Extractor):
 
     Include all of the subsidiaries, but ignore any nested structure and ignore any data unrelated to subsidiaries.
     """.strip()
+
+    def __init__(self, openai_api_key: str) -> None:
+        """Initialize the GPT extractor with the OpenAI API key."""
+        self._openai_client = OpenAiClient(api_key=openai_api_key)
 
     def _get_request_data_json(self, document: str) -> dict:
         """Build the OpenAI chat completions request payload for subsidiary extraction.
@@ -123,7 +125,7 @@ class GptExtractor(Extractor):
             RuntimeError: If the API returns any other error.
         """
         post_data = self._get_request_data_json(document)
-        response = self._OPENAI_CLIENT.query_endpoint(post_data)
+        response = self._openai_client.query_endpoint(post_data)
 
         if "error" in response:
             if response.get("status_code") == self._DOCUMENT_ERROR_STATUS_CODE:

--- a/src/idi_corporate_structure/processor/orchestrator.py
+++ b/src/idi_corporate_structure/processor/orchestrator.py
@@ -1,0 +1,55 @@
+"""Pipeline Orchestrator - Runs the corporate structure pipeline for a specified input file.
+
+Uses the `SubsidiaryPipeline` to process the input file and save the results to the output file.
+GPT extraction is performed in a separate thread.
+
+The orchestrator is responsible for running the pipeline.
+"""
+
+# Standard imports
+import argparse
+import datetime
+
+# Application imports
+from idi_corporate_structure.common.api import SecClient
+from idi_corporate_structure.processor.extractor import GptExtractor
+from idi_corporate_structure.processor.pipeline import SubsidiaryPipeline
+from idi_corporate_structure.processor.types import PipelineConfig
+
+
+def get_args() -> argparse.Namespace:
+    """Get command line arguments."""
+    parser = argparse.ArgumentParser(description="Corporate Structure Pipeline Orchestrator")
+    parser.add_argument("--input-file", type=str, required=True, help="Input file path")
+    parser.add_argument("--output-file", type=str, required=True, help="Output file path")
+    parser.add_argument("--failure-file", type=str, required=True, help="Failure file path")
+    parser.add_argument("--openai-api-key", type=str, required=True, help="OpenAI API key")
+    parser.add_argument("--rate-limit", type=float, default=0.2, help="Rate limit")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of workers")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Main function to run the pipeline orchestrator."""
+    start = datetime.datetime.now()
+    args = get_args()
+
+    config = PipelineConfig(
+        input_file=args.input_file,
+        output_file=args.output_file,
+        failure_file=args.failure_file,
+        rate_limit=args.rate_limit,
+        num_workers=args.num_workers,
+        openai_api_key=args.openai_api_key,
+    )
+    sec_client = SecClient(rate_limit=config.rate_limit)
+    extractor = GptExtractor(openai_api_key=config.openai_api_key)
+    pipeline = SubsidiaryPipeline(config=config, sec_client=sec_client, extractor=extractor)
+    pipeline.run()
+
+    end = datetime.datetime.now()
+    print(f"Elasped time: {end - start}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/idi_corporate_structure/processor/pipeline.py
+++ b/src/idi_corporate_structure/processor/pipeline.py
@@ -40,7 +40,15 @@ class Pipeline(ABC):
     def __init__(
         self, config: PipelineConfig, sec_client: SecClient, extractor: GptExtractor
     ) -> None:
-        """Initialize the pipeline with config, SEC client, and extractor."""
+        """Initialize the pipeline with config, SEC client, and extractor.
+
+        Args:
+            config: Pipeline configuration including input/output paths and tuning
+                parameters.
+            sec_client: Configured SEC EDGAR API client used for fetching filings.
+            extractor: Extractor instance responsible for parsing subsidiary data
+                from exhibit documents.
+        """
         self.config = config
         self.extractor = extractor
         self.sec_client = sec_client
@@ -48,25 +56,56 @@ class Pipeline(ABC):
 
     @abstractmethod
     def load_input(self) -> list:
-        """Load input data and return a list of items to process."""
+        """Load input data and return a list of items to process.
+
+        Returns:
+            List of input items. The concrete element type is defined by each
+            subclass (e.g. ``list[Filing]``).
+        """
         ...
 
     @abstractmethod
     def process(self, input_list: list) -> list:
-        """Process each item in the input list and return a list of results."""
+        """Process each item in the input list and return a list of results.
+
+        Args:
+            input_list: Items returned by :meth:`load_input`.
+
+        Returns:
+            List of processed results. The concrete element type is defined by
+            each subclass (e.g. ``list[Subsidiary]``).
+        """
         ...
 
     @abstractmethod
     def save_output(self, processed_list: list) -> None:
-        """Saves processed items list."""
+        """Persist the processed results to the configured output destination.
+
+        Args:
+            processed_list: Items returned by :meth:`process`.
+
+        Returns:
+            None
+        """
         ...
 
     @abstractmethod
     def display_stats(self) -> None:
-        """Display processing stats."""
+        """Log or display a summary of pipeline processing statistics.
+
+        Returns:
+            None
+        """
 
     def run(self) -> None:
-        """Run the pipeline."""
+        """Execute the full pipeline: load → process → save → display stats.
+
+        Calls :meth:`load_input`, :meth:`process`, :meth:`save_output`, and
+        :meth:`display_stats` in sequence, then logs the total elapsed time.
+
+        Returns:
+            None
+        """
         start_time = datetime.datetime.now()
 
         input_data = self.load_input()
@@ -93,7 +132,14 @@ class SubsidiaryPipeline(Pipeline):
     def __init__(
         self, config: PipelineConfig, sec_client: SecClient, extractor: GptExtractor
     ) -> None:
-        """Initialize the subsidiary pipeline with failure registry."""
+        """Initialize the subsidiary pipeline with failure registry.
+
+        Args:
+            config: Pipeline configuration including input/output paths, rate limit,
+                worker count, and failure flush threshold.
+            sec_client: Configured SEC EDGAR API client.
+            extractor: Extractor used to parse subsidiary data from exhibit documents.
+        """
         super().__init__(config, sec_client, extractor)
         self.logger = get_logger("SubsidiaryPipeline")
         self.failure_registry = FailureRegistry(
@@ -153,13 +199,23 @@ class SubsidiaryPipeline(Pipeline):
     def _zip_file_data(
         self, data: dict, filename: str, cik: str, zf: zipfile.ZipFile
     ) -> zip | None:
-        """Locate and returned zipped file data.
+        """Locate and return zipped filing data for a single CIK JSON file.
+
+        Combines recent filings from ``data`` with any overflow filings referenced
+        in ``data["filings"]["files"]``, then validates that all four parallel lists
+        (forms, accession numbers, primary documents, filing dates) have the same
+        length before zipping them together.
 
         Args:
-            data: Data to retrieve specific file data from
-            filename: Name of file data was retrieved from
-            cik: Identifier of file data was retrieved from
-            zf: Open ZipFile to read from.
+            data: Parsed CIK submissions JSON with ``filings.recent`` and optionally
+                ``filings.files`` overflow references.
+            filename: Source filename, used for failure registry entries and logging.
+            cik: CIK identifier for the company, used for failure registry entries.
+            zf: Open :class:`zipfile.ZipFile` from which overflow files are read.
+
+        Returns:
+            A ``zip`` iterator of ``(form, accession_number, primary_document,
+            filing_date)`` tuples, or ``None`` if the data is missing or inconsistent.
         """
         # Retrieve recent filings
         forms = data.get("filings", {}).get("recent", {}).get("form", [])
@@ -349,11 +405,21 @@ class SubsidiaryPipeline(Pipeline):
         return filings
 
     def _extract_worker(self, work_queue: queue.Queue, results_queue: queue.Queue) -> None:
-        """Extract worker for the pipeline.
+        """Worker thread that extracts subsidiaries from queued exhibit documents.
+
+        Runs as a daemon thread, consuming ``(filing, exhibit_contents)`` tuples from
+        ``work_queue`` and posting extracted ``list[Subsidiary]`` results to
+        ``results_queue``. Extraction errors are caught, logged, and recorded in the
+        failure registry so the worker loop continues.
 
         Args:
-            work_queue: Queue of filings and exhibit contents
-            results_queue: Queue of results
+            work_queue: Queue of ``(Filing, dict)`` tuples to process. Each dict has
+                ``"url"`` and ``"data"`` keys for the exhibit content.
+            results_queue: Queue to which extracted ``list[Subsidiary]`` results are
+                posted.
+
+        Returns:
+            None
         """
         while True:
             filing, exhibit_contents = work_queue.get()
@@ -393,12 +459,22 @@ class SubsidiaryPipeline(Pipeline):
         subsidiaries: list[Subsidiary],
         extract_bar: tqdm | None = None,
     ) -> None:
-        """Results worker for the pipeline.
+        """Worker thread that collects extracted subsidiaries from the results queue.
+
+        Runs as a daemon thread, consuming ``list[Subsidiary]`` batches from
+        ``results_queue`` and appending them to the shared ``subsidiaries`` list.
+        Optionally advances a tqdm progress bar on each batch completion.
 
         Args:
-            results_queue: Queue of results
-            subsidiaries: List of subsidiaries to add to
-            extract_bar: Optional tqdm progress bar to update on each completion.
+            results_queue: Queue of ``list[Subsidiary]`` batches produced by
+                :meth:`_extract_worker`.
+            subsidiaries: Shared list to which extracted subsidiaries are appended.
+                Must be safe for single-threaded append (only this worker writes).
+            extract_bar: Optional tqdm progress bar incremented by one for each
+                completed extraction task.
+
+        Returns:
+            None
         """
         while True:
             result = results_queue.get()
@@ -545,7 +621,20 @@ class SubsidiaryPipeline(Pipeline):
         return exhibit_content
 
     def process(self, input_list: list[Filing]) -> list[Subsidiary]:
-        """Process input filing list to retrieve subsidiary data."""
+        """Fetch exhibit content and extract subsidiaries from each filing.
+
+        Exhibit fetching (SEC HTTP calls) runs on the main thread; extraction is
+        parallelised across :attr:`~PipelineConfig.num_workers` daemon threads.
+        Progress is reported via two tqdm bars (fetching and extraction).
+
+        Args:
+            input_list: List of :class:`Filing` objects returned by
+                :meth:`load_input`.
+
+        Returns:
+            Deduplicated list of :class:`Subsidiary` objects extracted across all
+            filings.
+        """
         self.logger.info("Located %d subsidiaries", len(input_list))
         # Queues to store exhibit data and subsidiary data
         work_queue = queue.Queue(maxsize=self.config.num_workers * 2)
@@ -595,7 +684,18 @@ class SubsidiaryPipeline(Pipeline):
         return subsidiaries
 
     def save_output(self, processed_list: list[Subsidiary]) -> None:
-        """Save subsidiary list output."""
+        """Deduplicate and persist extracted subsidiaries as a Parquet file.
+
+        Drops duplicate rows keyed on ``(parent_cik, accession_number, name)`` and
+        appends a UTC ``date_added`` timestamp column before writing.
+
+        Args:
+            processed_list: List of :class:`Subsidiary` objects returned by
+                :meth:`process`.
+
+        Returns:
+            None
+        """
         df = pd.DataFrame([dataclasses.asdict(s) for s in processed_list])
         df = df.drop_duplicates(subset=["parent_cik", "accession_number", "name"])
         df["date_added"] = datetime.datetime.now(datetime.UTC).isoformat()
@@ -603,7 +703,14 @@ class SubsidiaryPipeline(Pipeline):
         self.logger.info("Saved %d subsidiaries to %s", len(df), self.config.output_file)
 
     def display_stats(self) -> None:
-        """Log pipeline stats on completion."""
+        """Log a formatted summary of pipeline statistics on completion.
+
+        Writes filing totals (total, skipped, failed) and subsidiary totals
+        (total, failed) to the logger at INFO level.
+
+        Returns:
+            None
+        """
         self.logger.info("=" * 40)
         self.logger.info("Pipeline Stats")
         self.logger.info("=" * 40)

--- a/src/idi_corporate_structure/processor/pipeline.py
+++ b/src/idi_corporate_structure/processor/pipeline.py
@@ -5,6 +5,7 @@ import dataclasses
 import datetime
 import io
 import json
+import os
 import queue
 import re
 import threading
@@ -126,7 +127,7 @@ class SubsidiaryPipeline(Pipeline):
     TWENTYONE = re.compile("[^0-9]21")
     IS_OVERFLOW = re.compile(r"-submissions-\d+\.json$")
 
-    _INPUT_SAMPLE_SIZE = 100  # TODO: Remove after done testing
+    _INPUT_SAMPLE_SIZE = int(os.environ.get("INPUT_SAMPLE_SIZE", 0))
     _SUPPORTED_EXHIBIT_EXTENSIONS = frozenset({"HTM", "HTML", "TXT", "PDF"})
 
     def __init__(
@@ -387,7 +388,8 @@ class SubsidiaryPipeline(Pipeline):
         filings = []
         with open_zip(self.config.input_file, headers=self.sec_client.SEC_HEADERS) as zf:
             namelist = zf.namelist()
-            namelist = namelist[: self._INPUT_SAMPLE_SIZE]  # TODO: Remove after done testing
+            if self._INPUT_SAMPLE_SIZE:
+                namelist = namelist[: self._INPUT_SAMPLE_SIZE]
             self.logger.info("Total # of files to process: %d", len(namelist))
 
             for filename in tqdm(namelist, desc="Retrieving filings"):
@@ -729,30 +731,3 @@ class SubsidiaryPipeline(Pipeline):
             super().run()
         finally:
             self.failure_registry.flush()
-
-
-if __name__ == "__main__":
-    # uv run python3 -m src.idi_corporate_structure.processor.pipeline
-    import datetime
-
-    start = datetime.datetime.now()
-
-    config = PipelineConfig(
-        # input_file="https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip",
-        input_file="/Users/ntebaldi/Documents/workspace/11hour/ftm2j/data/corporate-struct/input/submissions.zip",
-        failure_file="/Users/ntebaldi/Documents/workspace/11hour/ftm2j/data/corporate-struct/failures/failures.json",
-        output_file="/Users/ntebaldi/Documents/workspace/11hour/ftm2j/data/corporate-struct/output/subsidiaries.parquet",
-        rate_limit=0.2,
-        num_workers=10,
-    )
-
-    sec_client = SecClient(config.rate_limit)
-
-    extractor = GptExtractor()
-
-    sub_pipeline = SubsidiaryPipeline(config=config, sec_client=sec_client, extractor=extractor)
-
-    sub_pipeline.run()
-
-    end = datetime.datetime.now()
-    print(f"Elasped time: {end - start}")

--- a/src/idi_corporate_structure/processor/types.py
+++ b/src/idi_corporate_structure/processor/types.py
@@ -47,8 +47,9 @@ class PipelineConfig:
     input_file: str
     failure_file: str
     output_file: str
+    openai_api_key: str = ""
     failure_flush_every: int = 50
-    rate_limit: float = 0.1
+    rate_limit: float = 0.2
     num_workers: int = 10
 
     def __post_init__(self) -> None:

--- a/src/idi_corporate_structure/processor/types.py
+++ b/src/idi_corporate_structure/processor/types.py
@@ -9,6 +9,19 @@ _REMOTE_SCHEMES = ("s3://", "https://", "http://", "gs://")
 
 
 def _is_local(path: str) -> bool:
+    """Return True if the path refers to a local filesystem location.
+
+    A path is considered remote when it begins with one of the known URI
+    schemes in ``_REMOTE_SCHEMES`` (``s3://``, ``https://``, ``http://``,
+    ``gs://``).
+
+    Args:
+        path: File path or URI string to test.
+
+    Returns:
+        True if the path does not start with a known remote scheme,
+        False otherwise.
+    """
     return not path.startswith(_REMOTE_SCHEMES)
 
 

--- a/tests/processor/test_extractor.py
+++ b/tests/processor/test_extractor.py
@@ -22,8 +22,9 @@ class TestGptExtractor:
     """Tests for GptExtractor.extract()."""
 
     def test_returns_subsidiaries_from_gpt_response(self, sample_filing, mocker):
+        extractor = GptExtractor(openai_api_key="fake-key")
         mocker.patch.object(
-            GptExtractor._OPENAI_CLIENT,
+            extractor._openai_client,
             "query_endpoint",
             return_value=_make_openai_response(
                 [
@@ -32,7 +33,6 @@ class TestGptExtractor:
                 ]
             ),
         )
-        extractor = GptExtractor()
         result = extractor.extract(sample_filing, make_exhibit_response())
 
         assert len(result) == 2
@@ -43,12 +43,12 @@ class TestGptExtractor:
         assert result[1].location == "Ireland"
 
     def test_subsidiary_filing_fields_preserved(self, sample_filing, mocker):
+        extractor = GptExtractor(openai_api_key="fake-key")
         mocker.patch.object(
-            GptExtractor._OPENAI_CLIENT,
+            extractor._openai_client,
             "query_endpoint",
             return_value=_make_openai_response([{"name": "Sub LLC", "in": "Delaware"}]),
         )
-        extractor = GptExtractor()
         result = extractor.extract(sample_filing, make_exhibit_response())
         s = result[0]
 
@@ -59,46 +59,46 @@ class TestGptExtractor:
         assert s.accession_number == sample_filing.accession_number
 
     def test_exhibit_url_from_document(self, sample_filing, mocker):
+        extractor = GptExtractor(openai_api_key="fake-key")
         mocker.patch.object(
-            GptExtractor._OPENAI_CLIENT,
+            extractor._openai_client,
             "query_endpoint",
             return_value=_make_openai_response([{"name": "Sub LLC", "in": "Delaware"}]),
         )
-        extractor = GptExtractor()
         document = make_exhibit_response()
         result = extractor.extract(sample_filing, document)
 
         assert result[0].exhibit_url == document["url"]
 
     def test_null_location_becomes_empty_string(self, sample_filing, mocker):
+        extractor = GptExtractor(openai_api_key="fake-key")
         mocker.patch.object(
-            GptExtractor._OPENAI_CLIENT,
+            extractor._openai_client,
             "query_endpoint",
             return_value=_make_openai_response([{"name": "Sub LLC", "in": None}]),
         )
-        extractor = GptExtractor()
         result = extractor.extract(sample_filing, make_exhibit_response())
 
         assert result[0].location == ""
 
     def test_returns_empty_list_for_no_subsidiaries(self, sample_filing, mocker):
+        extractor = GptExtractor(openai_api_key="fake-key")
         mocker.patch.object(
-            GptExtractor._OPENAI_CLIENT,
+            extractor._openai_client,
             "query_endpoint",
             return_value=_make_openai_response([]),
         )
-        extractor = GptExtractor()
         result = extractor.extract(sample_filing, make_exhibit_response())
 
         assert result == []
 
     def test_raises_on_api_error(self, sample_filing, mocker):
+        extractor = GptExtractor(openai_api_key="fake-key")
         mocker.patch.object(
-            GptExtractor._OPENAI_CLIENT,
+            extractor._openai_client,
             "query_endpoint",
             return_value={"error": "connection timeout"},
         )
-        extractor = GptExtractor()
 
         with pytest.raises(RuntimeError):
             extractor.extract(sample_filing, make_exhibit_response())

--- a/tests/processor/test_pipeline.py
+++ b/tests/processor/test_pipeline.py
@@ -307,7 +307,7 @@ class TestFetchDirectory:
 
         assert result == items
 
-    def test_returns_empty_dict_when_no_directory_key(self, pipeline, sample_filing):
+    def test_returns_empty_list_when_no_directory_key(self, pipeline, sample_filing):
         pipeline.sec_client.query_endpoint.return_value = {
             "status_code": 200,
             "url": "https://...",
@@ -316,7 +316,7 @@ class TestFetchDirectory:
 
         result = pipeline._fetch_directory(sample_filing)
 
-        assert result == {}
+        assert result == []
 
     def test_records_failure_when_no_directory(self, pipeline, sample_filing):
         pipeline.sec_client.query_endpoint.return_value = {

--- a/tests/processor/test_types.py
+++ b/tests/processor/test_types.py
@@ -79,7 +79,7 @@ class TestPipelineConfig:
 
         assert config.input_file == str(input_zip)
         assert config.num_workers == 10  # default
-        assert config.rate_limit == 0.1  # default
+        assert config.rate_limit == 0.2  # default
 
     def test_raises_when_input_file_missing(self, tmp_path):
         with pytest.raises(FileNotFoundError, match="Input file not found"):


### PR DESCRIPTION
# PR: Fix Docstrings, Type Annotations, and Update README

**Branch:** `issue-7-readme` → `main`
**Issue:** #7

---

## Overview

- Updates the README to reflect the current pipeline architecture.
  - This will need to be further updated for orchestration and AWS infrastructure
- Audits and completes all docstrings and Python type annotations across the `src/idi_corporate_structure/` package
  - Every public and private function now carries a Google-style docstring with a description, Args, Returns, and Raises sections where applicable. 
  - Type annotations are tightened to eliminate implicit `None` defaults, bare `dict` returns, and unparameterised generics.

### Request for review

- It would be helpful to identify any gaps in the README, so far I have found the need for execution (orchestration), and infrastructure, plus the deployment pipeline (each of these will be covered as I implement the remaining issues.

---

## Changes

### Fix docstrings and type annotations (`00a2668`)

#### `common/api.py`

- `_query_with_error_handling`: `data`, `params`, and `headers` parameters changed from implicit `| None` defaults (`= None` without `None` in the union) to explicit `str | dict | None`, `dict | None`, and `dict | None`; docstring expanded to document the error-in-return-value contract (callers check for `"error"` key rather than catching exceptions)
- `query_endpoint` (abstract): `**kwargs` annotated as `**kwargs: object` (consistent with existing `get`/`post` convention); docstring expanded with Args and Returns sections
- All concrete `query_endpoint` overrides (`LsegEntitySearch`, `LsegRecordMatch`, `LSEGEntityLookup`, `GeonamesApi`, `SecClient`, `OpenAiClient`): return types narrowed from bare `dict` to `dict[str, Any]`; `GeonamesApi.query_endpoint` gained a missing Returns section; all descriptions clarified
- `OpenAiClient.query_endpoint`: `data` parameter type corrected from `str | dict = None` to `str | dict | None = None`

#### `common/failures.py`

- `FailureClassifier.do_not_retry`: return type narrowed from `frozenset` to `frozenset[StrEnum]`
- `FailureClassifier.classify_from_response`: `**kwargs` annotated as `**kwargs: object`
- `FailureRegistry.load`: docstring expanded with Returns and Raises sections — documents the silent `JSONDecodeError` swallow and the S3 `ClientError` that propagates
- `FailureRegistry.save`: docstring expanded with Returns section and description of the on-disk format written

#### `common/storage.py`

- `load_json`: docstring rewritten with full Args, Returns, and Raises sections — documents missing-file behaviour, valid `return_type` values, and exceptions that propagate
- `open_zip`: `file_path` arg description corrected from "path to the JSON file" to "path to the ZIP file"; Yields and Raises sections added

#### `processor/types.py`

- `_is_local`: full docstring added (was entirely missing) — description, Args, Returns

#### `processor/extractor.py`

- `GptExtractor._get_request_data_json`: full docstring added (was entirely missing) — documents the structured-output schema and return shape
- `GptExtractor._summarize`: return annotation corrected from `str` to `dict` (the method returns `json.loads(content)`, a dict); docstring Returns updated to describe the `"subsidiaries"` key; Raises section added for `DocumentError` and `RuntimeError`
- `GptExtractor.extract`: one-liner expanded to include Args, Returns, and Raises sections consistent with the parent abstract method

#### `processor/pipeline.py`

- `Pipeline.__init__`: Args section added
- `Pipeline.load_input`, `process`, `save_output`, `display_stats`: expanded from one-liners to full Args/Returns docstrings
- `Pipeline.run`: expanded to describe the load → process → save → stats sequence and elapsed-time logging
- `SubsidiaryPipeline.__init__`: Args section added
- `SubsidiaryPipeline._zip_file_data`: typo "Locate and returned" → "Locate and return"; Returns section added describing the zip iterator and the `None` failure cases
- `SubsidiaryPipeline._extract_worker`, `_results_worker`: full docstrings added with Returns: None
- `SubsidiaryPipeline.process`, `save_output`, `display_stats`: expanded from one-liners to full Args/Returns docstrings

### Update README (`35c1046`)

- Rewrote README to describe the current project purpose, repository layout, data pipeline stages (input → load → process → save), and component responsibilities
- Added architecture overview covering `common/` utilities and `processor/` pipeline components
- Added setup and usage instructions reflecting the `uv`-based workflow

---

## Test results

129 tests pass. 

```
129 passed in 0.25s
```

Linting + formatting pass as well.
