### PR TITLE
Implemented corporate processor orchestration and containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.egg-info
 .claude
 .venv
+logs/

--- a/README.md
+++ b/README.md
@@ -56,16 +56,17 @@ AWS credentials are required only if using S3 paths for input or output.
 ### Run
 
 ```bash
-uv run python -m idi_corporate_structure.processor.pipeline
+uv run python3 -m src.idi_corporate_structure.processor.orchestrator \
+    --input-file "/local/input/submissions.zip" \
+    --output-file "/local/output/subsidiaries.parquet" \
+    --failure-file "/local/failures/failures.json" \
+    --openai-api-key "sk-proj-xxxxxxxxxxxxx" \
+    --rate-limit 0.2 \
+    --num-workers 10
 ```
 
-The `submissions.zip` bulk data file is available from SEC EDGAR:
-
-```
-https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip
-```
-
-And can be read in via HTTP or local disk.
+- To read the `submissions.zip` file in via HTTP from SEC EDGAR, pass the following URL into the `--input-file` argument:
+    - `https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip`
 
 ### Configuration Reference
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,74 @@ uv run python3 -m src.idi_corporate_structure.processor.orchestrator \
 | `output_file` | — | Required. Path for Parquet output (local or `s3://`) |
 | `failure_file` | — | Required. Path to failures JSON; parent directory created if missing |
 | `failure_flush_every` | `50` | Write failures to disk after every N new entries |
-| `rate_limit` | `0.1` | Seconds between SEC HTTP requests (SEC limit: 10 req/s) |
+| `rate_limit` | `0.2` | Seconds between SEC HTTP requests (SEC limit: 10 req/s) |
 | `num_workers` | `10` | Number of concurrent GPT extraction worker threads |
+
+---
+
+## Container Usage
+
+The pipeline ships with a multi-stage Dockerfile and Docker Compose files for running the orchestrator in a container.
+
+### Files
+
+| File | Purpose |
+|---|---|
+| `dockerfiles/Dockerfile.orchestrator` | Multi-stage `python:3.13-slim` image; non-root `pipeline` user |
+| `compose.yml` | Service definition; pulls image from registry |
+| `compose.override.yml` | Adds `build:` block for local development; merged automatically by `docker compose` |
+
+### Environment Variables
+
+All required variables must be set before running. Optional variables fall back to the listed defaults.
+
+#### Required
+
+| Variable | Description |
+|---|---|
+| `OPENAI_API_KEY` | OpenAI API key for GPT extraction |
+| `INPUT_MOUNT_SOURCE` | Host directory containing the input file (e.g. `/data/input`) |
+| `INPUT_FILE` | Container-side path to the input file (e.g. `/data/input/submissions.zip`); can be an `https://` URL instead of a local path, in which case `INPUT_MOUNT_SOURCE` is unused |
+| `OUTPUT_MOUNT_SOURCE` | Host directory for Parquet output (e.g. `/data/output`) |
+| `FAILURE_MOUNT_SOURCE` | Host directory for failures JSON (e.g. `/data/failures`) |
+| `LOG_DIR` | Host directory for log files (e.g. `/data/logs`) |
+
+#### Optional
+
+| Variable | Default | Description |
+|---|---|---|
+| `OUTPUT_FILE` | `/data/output/output.parquet` | Container-side path for Parquet output |
+| `FAILURE_FILE` | `/data/failures/failures.json` | Container-side path for failures JSON |
+| `RATE_LIMIT` | `0.2` | Seconds between SEC HTTP requests |
+| `NUM_WORKERS` | `10` | Number of concurrent GPT extraction worker threads |
+| `INPUT_SAMPLE_SIZE` | `0` | Limit input to N files for testing (`0` = no limit) |
+| `AWS_REGION` | `us-east-2` | AWS region for S3 and CloudWatch |
+| `CLOUDWATCH_LOGS_ENABLED` | `false` | Enable CloudWatch log shipping |
+| `ORCHESTRATOR_IMAGE` | `ghcr.io/dsi-clinic/idi-corporate-structure-orchestrator:latest` | Image to pull on EC2 (ignored when building locally) |
+
+### Run
+
+**Local — build from source and run:**
+
+```bash
+export OPENAI_API_KEY="sk-proj-xxxxxxxxxxxxx"
+export INPUT_MOUNT_SOURCE="/path/to/input"       # must contain submissions.zip
+export OUTPUT_MOUNT_SOURCE="/path/to/output"
+export FAILURE_MOUNT_SOURCE="/path/to/failures"
+export LOG_DIR="/path/to/logs"
+
+docker compose up --build orchestrator
+```
+
+`compose.override.yml` is merged automatically when running locally, which adds the `build:` block so the image is built from source rather than pulled.
+
+**Detached (background):**
+
+```bash
+docker compose up -d --build orchestrator
+docker compose logs -f orchestrator   # tail logs
+docker compose down                   # stop
+```
 
 ---
 

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -1,0 +1,9 @@
+# Local development override — automatically merged by `docker compose` when running locally.
+# Adds build blocks so services are built from source instead of pulled from the registry.
+# On EC2, only compose.yml is used (no build blocks, pulls from ECR via ORCHESTRATOR_IMAGE).
+# See: https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/
+services:
+  orchestrator:
+    build:
+      context: .
+      dockerfile: dockerfiles/Dockerfile.orchestrator

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,46 @@
+services:
+
+  # ---------------------------------------------------------------------------
+  # Corporate structure pipeline
+  # ---------------------------------------------------------------------------
+  orchestrator:
+    image: ${ORCHESTRATOR_IMAGE:-ghcr.io/dsi-clinic/idi-corporate-structure-orchestrator:latest}
+    container_name: idi-corporate-structure-orchestrator
+
+    environment:
+      - AWS_REGION=${AWS_REGION:-us-east-2}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:?OPENAI_API_KEY is required}
+      - INPUT_FILE=${INPUT_FILE:-/data/input/submissions.zip}
+      - OUTPUT_FILE=${OUTPUT_FILE:-/data/output/subsidiaries.parquet}
+      - FAILURE_FILE=${FAILURE_FILE:-/data/failures/failures.json}
+      - RATE_LIMIT=${RATE_LIMIT:-0.2}
+      - NUM_WORKERS=${NUM_WORKERS:-10}
+      - CLOUDWATCH_LOGS_ENABLED=${CLOUDWATCH_LOGS_ENABLED:-false}
+      - INPUT_SAMPLE_SIZE=${INPUT_SAMPLE_SIZE:-0}
+
+    volumes:
+      - ${INPUT_MOUNT_SOURCE:?INPUT_MOUNT_SOURCE is required (host directory containing the input file)}:/data/input:ro
+      - ${OUTPUT_MOUNT_SOURCE:?OUTPUT_MOUNT_SOURCE is required (host directory for output files)}:/data/output
+      - ${FAILURE_MOUNT_SOURCE:?FAILURE_MOUNT_SOURCE is required (host directory for failure files)}:/data/failures
+      - ${LOG_DIR:?LOG_DIR is required (host directory for log files)}:/logs
+
+    entrypoint: ["/bin/sh", "-c"]
+    command: >
+      "python -m idi_corporate_structure.processor.orchestrator
+      --input-file $${INPUT_FILE:-/data/input/submissions.zip}
+      --output-file $${OUTPUT_FILE:-/data/output/subsidiaries.parquet}
+      --failure-file $${FAILURE_FILE:-/data/failures/failures.json}
+      --openai-api-key ${OPENAI_API_KEY}
+      --rate-limit ${RATE_LIMIT:-0.2}
+      --num-workers ${NUM_WORKERS:-10}
+      2>&1 | tee /logs/orchestrator_$(date +%Y%m%d_%H%M%S).log"
+
+    # Retry up to 3 times if the process exits with a non-zero code
+    restart: on-failure
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+        compress: "true"

--- a/dockerfiles/Dockerfile.orchestrator
+++ b/dockerfiles/Dockerfile.orchestrator
@@ -1,0 +1,51 @@
+# Multi-stage build for efficient image size
+FROM python:3.13-slim AS builder
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy dependency files
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+
+# Install Python dependencies
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -e .
+
+# Final stage - minimal runtime image
+FROM python:3.13-slim
+
+# Create non-root user for security
+RUN useradd -m -u 1000 pipeline && \
+    mkdir -p /data/input /data/output /data/failures /logs && \
+    chown -R pipeline:pipeline /data /logs
+
+# Set working directory
+WORKDIR /app
+
+# Copy installed packages from builder
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+COPY --from=builder /app /app
+
+# Switch to non-root user
+USER pipeline
+
+# Create volume mount points
+VOLUME ["/data/input", "/data/output", "/data/failures", "/logs"]
+
+# Set Python unbuffered mode for real-time logging
+ENV PYTHONUNBUFFERED=1
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import sys; sys.exit(0)"
+
+# Default command (can be overridden in compose)
+ENTRYPOINT ["python", "-m", "idi_corporate_structure.processor.orchestrator"]
+CMD ["--help"]

--- a/src/idi_corporate_structure/processor/extractor.py
+++ b/src/idi_corporate_structure/processor/extractor.py
@@ -37,7 +37,6 @@ class GptExtractor(Extractor):
     """Extracts subsidiaries from a single exhibit document using GPT."""
 
     _DOCUMENT_ERROR_STATUS_CODE = 400
-    _OPENAI_CLIENT = OpenAiClient(api_key=os.environ.get("OPENAI_API_KEY", ""))
     _SYSTEM_PROMPT = """
     Given a table of a company's subsidiaries (in Markdown or raw text, previously converted from PDF), format them as a JSON, like
 
@@ -53,6 +52,10 @@ class GptExtractor(Extractor):
 
     Include all of the subsidiaries, but ignore any nested structure and ignore any data unrelated to subsidiaries.
     """.strip()
+
+    def __init__(self, openai_api_key: str) -> None:
+        """Initialize the GPT extractor with the OpenAI API key."""
+        self._openai_client = OpenAiClient(api_key=openai_api_key)
 
     def _get_request_data_json(self, document: str) -> dict:
         """Build the OpenAI chat completions request payload for subsidiary extraction.
@@ -123,7 +126,7 @@ class GptExtractor(Extractor):
             RuntimeError: If the API returns any other error.
         """
         post_data = self._get_request_data_json(document)
-        response = self._OPENAI_CLIENT.query_endpoint(post_data)
+        response = self._openai_client.query_endpoint(post_data)
 
         if "error" in response:
             if response.get("status_code") == self._DOCUMENT_ERROR_STATUS_CODE:

--- a/src/idi_corporate_structure/processor/extractor.py
+++ b/src/idi_corporate_structure/processor/extractor.py
@@ -2,7 +2,6 @@
 
 # Standard imports
 import json
-import os
 from abc import ABC, abstractmethod
 
 # Application imports

--- a/src/idi_corporate_structure/processor/orchestrator.py
+++ b/src/idi_corporate_structure/processor/orchestrator.py
@@ -16,6 +16,7 @@ from idi_corporate_structure.processor.extractor import GptExtractor
 from idi_corporate_structure.processor.pipeline import SubsidiaryPipeline
 from idi_corporate_structure.processor.types import PipelineConfig
 
+
 def get_args() -> argparse.Namespace:
     """Get command line arguments."""
     parser = argparse.ArgumentParser(description="Corporate Structure Pipeline Orchestrator")
@@ -27,9 +28,9 @@ def get_args() -> argparse.Namespace:
     parser.add_argument("--num-workers", type=int, default=10, help="Number of workers")
     return parser.parse_args()
 
+
 def main() -> None:
     """Main function to run the pipeline orchestrator."""
-
     start = datetime.datetime.now()
     args = get_args()
 
@@ -48,6 +49,7 @@ def main() -> None:
 
     end = datetime.datetime.now()
     print(f"Elasped time: {end - start}")
+
 
 if __name__ == "__main__":
     main()

--- a/src/idi_corporate_structure/processor/orchestrator.py
+++ b/src/idi_corporate_structure/processor/orchestrator.py
@@ -1,0 +1,53 @@
+"""Pipeline Orchestrator - Runs the corporate structure pipeline for a specified input file.
+
+Uses the `SubsidiaryPipeline` to process the input file and save the results to the output file.
+GPT extraction is performed in a separate thread.
+
+The orchestrator is responsible for running the pipeline.
+"""
+
+# Standard imports
+import argparse
+import datetime
+
+# Application imports
+from idi_corporate_structure.common.api import SecClient
+from idi_corporate_structure.processor.extractor import GptExtractor
+from idi_corporate_structure.processor.pipeline import SubsidiaryPipeline
+from idi_corporate_structure.processor.types import PipelineConfig
+
+def get_args() -> argparse.Namespace:
+    """Get command line arguments."""
+    parser = argparse.ArgumentParser(description="Corporate Structure Pipeline Orchestrator")
+    parser.add_argument("--input-file", type=str, required=True, help="Input file path")
+    parser.add_argument("--output-file", type=str, required=True, help="Output file path")
+    parser.add_argument("--failure-file", type=str, required=True, help="Failure file path")
+    parser.add_argument("--openai-api-key", type=str, required=True, help="OpenAI API key")
+    parser.add_argument("--rate-limit", type=float, default=0.2, help="Rate limit")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of workers")
+    return parser.parse_args()
+
+def main() -> None:
+    """Main function to run the pipeline orchestrator."""
+
+    start = datetime.datetime.now()
+    args = get_args()
+
+    config = PipelineConfig(
+        input_file=args.input_file,
+        output_file=args.output_file,
+        failure_file=args.failure_file,
+        rate_limit=args.rate_limit,
+        num_workers=args.num_workers,
+        openai_api_key=args.openai_api_key,
+    )
+    sec_client = SecClient(rate_limit=config.rate_limit)
+    extractor = GptExtractor(openai_api_key=config.openai_api_key)
+    pipeline = SubsidiaryPipeline(config=config, sec_client=sec_client, extractor=extractor)
+    pipeline.run()
+
+    end = datetime.datetime.now()
+    print(f"Elasped time: {end - start}")
+
+if __name__ == "__main__":
+    main()

--- a/src/idi_corporate_structure/processor/pipeline.py
+++ b/src/idi_corporate_structure/processor/pipeline.py
@@ -729,30 +729,3 @@ class SubsidiaryPipeline(Pipeline):
             super().run()
         finally:
             self.failure_registry.flush()
-
-
-if __name__ == "__main__":
-    # uv run python3 -m src.idi_corporate_structure.processor.pipeline
-    import datetime
-
-    start = datetime.datetime.now()
-
-    config = PipelineConfig(
-        # input_file="https://www.sec.gov/Archives/edgar/daily-index/bulkdata/submissions.zip",
-        input_file="/Users/ntebaldi/Documents/workspace/11hour/ftm2j/data/corporate-struct/input/submissions.zip",
-        failure_file="/Users/ntebaldi/Documents/workspace/11hour/ftm2j/data/corporate-struct/failures/failures.json",
-        output_file="/Users/ntebaldi/Documents/workspace/11hour/ftm2j/data/corporate-struct/output/subsidiaries.parquet",
-        rate_limit=0.2,
-        num_workers=10,
-    )
-
-    sec_client = SecClient(config.rate_limit)
-
-    extractor = GptExtractor()
-
-    sub_pipeline = SubsidiaryPipeline(config=config, sec_client=sec_client, extractor=extractor)
-
-    sub_pipeline.run()
-
-    end = datetime.datetime.now()
-    print(f"Elasped time: {end - start}")

--- a/src/idi_corporate_structure/processor/pipeline.py
+++ b/src/idi_corporate_structure/processor/pipeline.py
@@ -5,6 +5,7 @@ import dataclasses
 import datetime
 import io
 import json
+import os
 import queue
 import re
 import threading
@@ -126,7 +127,7 @@ class SubsidiaryPipeline(Pipeline):
     TWENTYONE = re.compile("[^0-9]21")
     IS_OVERFLOW = re.compile(r"-submissions-\d+\.json$")
 
-    _INPUT_SAMPLE_SIZE = 100  # TODO: Remove after done testing
+    _INPUT_SAMPLE_SIZE = int(os.environ.get("INPUT_SAMPLE_SIZE", 0))
     _SUPPORTED_EXHIBIT_EXTENSIONS = frozenset({"HTM", "HTML", "TXT", "PDF"})
 
     def __init__(
@@ -387,7 +388,8 @@ class SubsidiaryPipeline(Pipeline):
         filings = []
         with open_zip(self.config.input_file, headers=self.sec_client.SEC_HEADERS) as zf:
             namelist = zf.namelist()
-            namelist = namelist[: self._INPUT_SAMPLE_SIZE]  # TODO: Remove after done testing
+            if self._INPUT_SAMPLE_SIZE:
+                namelist = namelist[: self._INPUT_SAMPLE_SIZE]
             self.logger.info("Total # of files to process: %d", len(namelist))
 
             for filename in tqdm(namelist, desc="Retrieving filings"):

--- a/src/idi_corporate_structure/processor/types.py
+++ b/src/idi_corporate_structure/processor/types.py
@@ -47,8 +47,9 @@ class PipelineConfig:
     input_file: str
     failure_file: str
     output_file: str
+    openai_api_key: str
     failure_flush_every: int = 50
-    rate_limit: float = 0.1
+    rate_limit: float = 0.2
     num_workers: int = 10
 
     def __post_init__(self) -> None:

--- a/src/idi_corporate_structure/processor/types.py
+++ b/src/idi_corporate_structure/processor/types.py
@@ -47,7 +47,7 @@ class PipelineConfig:
     input_file: str
     failure_file: str
     output_file: str
-    openai_api_key: str
+    openai_api_key: str = ""
     failure_flush_every: int = 50
     rate_limit: float = 0.2
     num_workers: int = 10

--- a/tests/processor/test_extractor.py
+++ b/tests/processor/test_extractor.py
@@ -22,8 +22,9 @@ class TestGptExtractor:
     """Tests for GptExtractor.extract()."""
 
     def test_returns_subsidiaries_from_gpt_response(self, sample_filing, mocker):
+        extractor = GptExtractor(openai_api_key="fake-key")
         mocker.patch.object(
-            GptExtractor._OPENAI_CLIENT,
+            extractor._openai_client,
             "query_endpoint",
             return_value=_make_openai_response(
                 [
@@ -32,7 +33,6 @@ class TestGptExtractor:
                 ]
             ),
         )
-        extractor = GptExtractor()
         result = extractor.extract(sample_filing, make_exhibit_response())
 
         assert len(result) == 2
@@ -43,12 +43,12 @@ class TestGptExtractor:
         assert result[1].location == "Ireland"
 
     def test_subsidiary_filing_fields_preserved(self, sample_filing, mocker):
+        extractor = GptExtractor(openai_api_key="fake-key")
         mocker.patch.object(
-            GptExtractor._OPENAI_CLIENT,
+            extractor._openai_client,
             "query_endpoint",
             return_value=_make_openai_response([{"name": "Sub LLC", "in": "Delaware"}]),
         )
-        extractor = GptExtractor()
         result = extractor.extract(sample_filing, make_exhibit_response())
         s = result[0]
 
@@ -59,46 +59,46 @@ class TestGptExtractor:
         assert s.accession_number == sample_filing.accession_number
 
     def test_exhibit_url_from_document(self, sample_filing, mocker):
+        extractor = GptExtractor(openai_api_key="fake-key")
         mocker.patch.object(
-            GptExtractor._OPENAI_CLIENT,
+            extractor._openai_client,
             "query_endpoint",
             return_value=_make_openai_response([{"name": "Sub LLC", "in": "Delaware"}]),
         )
-        extractor = GptExtractor()
         document = make_exhibit_response()
         result = extractor.extract(sample_filing, document)
 
         assert result[0].exhibit_url == document["url"]
 
     def test_null_location_becomes_empty_string(self, sample_filing, mocker):
+        extractor = GptExtractor(openai_api_key="fake-key")
         mocker.patch.object(
-            GptExtractor._OPENAI_CLIENT,
+            extractor._openai_client,
             "query_endpoint",
             return_value=_make_openai_response([{"name": "Sub LLC", "in": None}]),
         )
-        extractor = GptExtractor()
         result = extractor.extract(sample_filing, make_exhibit_response())
 
         assert result[0].location == ""
 
     def test_returns_empty_list_for_no_subsidiaries(self, sample_filing, mocker):
+        extractor = GptExtractor(openai_api_key="fake-key")
         mocker.patch.object(
-            GptExtractor._OPENAI_CLIENT,
+            extractor._openai_client,
             "query_endpoint",
             return_value=_make_openai_response([]),
         )
-        extractor = GptExtractor()
         result = extractor.extract(sample_filing, make_exhibit_response())
 
         assert result == []
 
     def test_raises_on_api_error(self, sample_filing, mocker):
+        extractor = GptExtractor(openai_api_key="fake-key")
         mocker.patch.object(
-            GptExtractor._OPENAI_CLIENT,
+            extractor._openai_client,
             "query_endpoint",
             return_value={"error": "connection timeout"},
         )
-        extractor = GptExtractor()
 
         with pytest.raises(RuntimeError):
             extractor.extract(sample_filing, make_exhibit_response())

--- a/tests/processor/test_types.py
+++ b/tests/processor/test_types.py
@@ -79,7 +79,7 @@ class TestPipelineConfig:
 
         assert config.input_file == str(input_zip)
         assert config.num_workers == 10  # default
-        assert config.rate_limit == 0.1  # default
+        assert config.rate_limit == 0.2  # default
 
     def test_raises_when_input_file_missing(self, tmp_path):
         with pytest.raises(FileNotFoundError, match="Input file not found"):


### PR DESCRIPTION
# PR: Orchestrator and Docker Infrastructure

**Branch:** `issue-13-orchestration` → `issue-7-readme`
**Issue:** #13

---

## Overview

Introduces the orchestrator entry point for the corporate structure pipeline and the Docker infrastructure to run it in a container.

- The `__main__` block previously used for ad-hoc execution in `pipeline.py` is replaced with a proper `orchestrator.py` module that wires together CLI arguments, `PipelineConfig`, `SecClient`, `GptExtractor`, and `SubsidiaryPipeline`.
- A multi-stage Dockerfile, `compose.yml`, and `compose.override.yml` allow the pipeline to be executed locally from source or pulled from a registry on EC2 or ECS task.

---

## Changes

### Orchestrator entry point (`becf0eb`)

- `orchestrator.py` added as the pipeline entry point, executable via `python -m idi_corporate_structure.processor.orchestrator`
- `get_args()` parses six CLI arguments: `--input-file`, `--output-file`, `--failure-file`, `--openai-api-key` (required), `--rate-limit` (default `0.2`), `--num-workers` (default `10`)
- `README.md` updated with run instructions using the new module path and argument names

### Docker infrastructure (`17d2cdd`)

- `dockerfiles/Dockerfile.orchestrator`: multi-stage build on `python:3.13-slim` ; and includes a healthcheck
- `compose.yml`: single `orchestrator` service; all six pipeline arguments driven by environment variables ; host-side directories mounted ; json-file logging driver with rotation
- `compose.override.yml`: adds `build:` block pointing at `dockerfiles/Dockerfile.orchestrator` for local development; automatically merged by `docker compose`
- `pipeline.py`: `INPUT_SAMPLE_SIZE` env var wired to `_INPUT_SAMPLE_SIZE` class attribute via `os.environ.get` for development sampling

### Test fixes (`9f3fc93`)

- `test_extractor.py`: all 6 `TestGptExtractor` tests updated — extractor now instantiated with `GptExtractor(openai_api_key="fake-key")` first, then `mocker.patch.object(extractor._openai_client, ...)` patches the instance attribute (replacing the defunct `GptExtractor._OPENAI_CLIENT` class-attribute patch)
- `test_types.py`: `rate_limit` default assertion corrected from `0.1` to `0.2`; `openai_api_key` no longer required in `PipelineConfig` test construction calls

---

## Test results

All 129 unit tests pass with no failures.

```
============================= 129 passed in 0.20s ==============================
```

Lint and formatting pass as well.