### PR TITLE
ci: bump shared pipeline pin to v0.1.11 (#47)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   checks:
-    uses: dsi-clinic/idi-ftm2j-shared/.github/workflows/pipeline-checks.yml@v0.1.10
+    uses: dsi-clinic/idi-ftm2j-shared/.github/workflows/pipeline-checks.yml@v0.1.11
     secrets: inherit
     with:
       app-name: corporate-structure

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 # Post-merge pipeline. Thin caller of the shared composition pipeline-docker.yml
-# (version -> docker -> deploy-pulumi -> sync-ecr, plus sync-dev), pinned to an
+# (version -> docker -> sync-ecr -> deploy-pulumi, plus sync-dev), pinned to an
 # exact release of dsi-clinic/idi-ftm2j-shared. Bump the @vX.Y.Z pin to upgrade.
 #
 # NOTE: pin a release that includes the env-secret + caller-permissions fixes
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: dsi-clinic/idi-ftm2j-shared/.github/workflows/pipeline-docker.yml@v0.1.10
+    uses: dsi-clinic/idi-ftm2j-shared/.github/workflows/pipeline-docker.yml@v0.1.11
     secrets: inherit
     with:
       app-name: corporate-structure


### PR DESCRIPTION
Picks up the pipeline-docker reassessment fixes from idi-ftm2j-shared:
- no per-filter change detection (full chain on every non-doc push)
- sync-ecr now runs before deploy-pulumi (image tag in ECR before Pulumi points the ECS task def at it)

Also corrects the deploy.yml header comment to the new job order (version -> docker -> sync-ecr -> deploy-pulumi).